### PR TITLE
Add typer as dependency of cli

### DIFF
--- a/metldata/__init__.py
+++ b/metldata/__init__.py
@@ -15,4 +15,4 @@
 
 """Short description of package"""  # Please adapt to package
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ packages = find:
 install_requires =
     hexkit[mongodb]==0.10.0
     ghga-service-commons[api,auth]==0.4.2
+    typer==0.7.0
     linkml-runtime==1.4.2
     linkml-validator==0.4.5
 


### PR DESCRIPTION
To start the cli, we need the typer library.