### PR TITLE
Create summary statistics after loading (GIM-309)

### DIFF
--- a/metldata/artifacts_rest/models.py
+++ b/metldata/artifacts_rest/models.py
@@ -16,12 +16,18 @@
 
 """Data models."""
 
-from typing import Optional
+from typing import Optional, TypedDict
 
+from ghga_service_commons.utils.utc_dates import DateTimeUTC
 from pydantic import BaseModel, Field, validator
 
 from metldata.custom_types import Json
 from metldata.model_utils.anchors import AnchorPoint
+
+try:  # workaround for https://github.com/pydantic/pydantic/issues/5821
+    from typing_extensions import Literal
+except ImportError:
+    from typing import Literal  # type: ignore
 
 
 class ArtifactResource(BaseModel):
@@ -62,8 +68,8 @@ class ArtifactInfo(BaseModel):
         ...,
         description=(
             "A dictionary of resource classes for this artifact."
-            + " The keys are the names of the classes. The values are the"
-            + " corresponding class models."
+            + " The keys are the names of the classes."
+            + " The values are the corresponding class models."
         ),
     )
 
@@ -85,3 +91,31 @@ class ArtifactInfo(BaseModel):
                 )
 
         return value
+
+
+class ResourceCount(TypedDict):
+    """Number of instances of a resource."""
+
+    count: int
+
+
+class ResourceStats(ResourceCount, total=False):
+    """Summary statistics for a resource."""
+
+    stats: dict[str, dict[str, int]]
+
+
+class GlobalStats(BaseModel):
+    """Model to describe statistical information on all resources."""
+
+    id: Literal["global"]
+    created: DateTimeUTC = Field(..., description="When these stats were created.")
+
+    resource_stats: dict[str, ResourceStats] = Field(
+        ...,
+        description=(
+            "A dictionary of global resource stats."
+            + " The keys are the names of the classes."
+            + " The values are the corresponding summary statistics."
+        ),
+    )

--- a/metldata/combined.py
+++ b/metldata/combined.py
@@ -24,6 +24,7 @@ from metldata.artifacts_rest.api_factory import (
     rest_api_factory as query_rest_api_factory,
 )
 from metldata.config import Config
+from metldata.load.aggregator import MongoDbAggregator
 from metldata.load.api import rest_api_factory as load_rest_api_factory
 
 
@@ -36,10 +37,12 @@ async def get_app(config: Config) -> FastAPI:
     )
     configure_app(app=app, config=config)
     dao_factory = MongoDbDaoFactory(config=config)
+    db_aggregator = MongoDbAggregator(config=config)
 
     load_router = await load_rest_api_factory(
         artifact_infos=config.artifact_infos,
         dao_factory=dao_factory,
+        db_aggregator=db_aggregator,
         token_hashes=config.loader_token_hashes,
     )
 

--- a/metldata/load/aggregator.py
+++ b/metldata/load/aggregator.py
@@ -1,0 +1,54 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Protocol and provider for a database aggregator."""
+
+from abc import abstractmethod
+from typing import Any
+
+from hexkit.protocols.dao import DaoFactoryProtocol
+from hexkit.providers.mongodb import MongoDbDaoFactory
+
+
+class DbAggregator(DaoFactoryProtocol):
+    """A DaoFactory that can also aggregate and write documents."""
+
+    @abstractmethod
+    async def aggregate(
+        self, *, collection_name: str, pipeline: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Run the given aggregation pipeline."""
+        ...
+
+    @abstractmethod
+    async def write(self, *, collection_name, document) -> None:
+        """Write the given document to the given collection."""
+
+
+class MongoDbAggregator(MongoDbDaoFactory, DbAggregator):
+    """A MongoDB-based DaoFactory that can also aggregate and write documents."""
+
+    async def aggregate(
+        self, *, collection_name: str, pipeline: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Run the given aggregation pipeline."""
+        collection = self._db[collection_name]
+        return [item async for item in collection.aggregate(pipeline=pipeline)]
+
+    async def write(self, *, collection_name, document) -> None:
+        """Write the given document to the given collection."""
+        collection = self._db[collection_name]
+        await collection.replace_one({"_id": document["_id"]}, document, upsert=True)

--- a/metldata/load/aggregator.py
+++ b/metldata/load/aggregator.py
@@ -24,7 +24,7 @@ from hexkit.providers.mongodb import MongoDbDaoFactory
 
 
 class DbAggregator(DaoFactoryProtocol):
-    """A DaoFactory that can also aggregate and write documents."""
+    """A DaoFactory that can also aggregate."""
 
     @abstractmethod
     async def aggregate(
@@ -33,13 +33,9 @@ class DbAggregator(DaoFactoryProtocol):
         """Run the given aggregation pipeline."""
         ...
 
-    @abstractmethod
-    async def write(self, *, collection_name, document) -> None:
-        """Write the given document to the given collection."""
-
 
 class MongoDbAggregator(MongoDbDaoFactory, DbAggregator):
-    """A MongoDB-based DaoFactory that can also aggregate and write documents."""
+    """A MongoDB-based DaoFactory that can also aggregate."""
 
     async def aggregate(
         self, *, collection_name: str, pipeline: list[dict[str, Any]]
@@ -47,8 +43,3 @@ class MongoDbAggregator(MongoDbDaoFactory, DbAggregator):
         """Run the given aggregation pipeline."""
         collection = self._db[collection_name]
         return [item async for item in collection.aggregate(pipeline=pipeline)]
-
-    async def write(self, *, collection_name, document) -> None:
-        """Write the given document to the given collection."""
-        collection = self._db[collection_name]
-        await collection.replace_one({"_id": document["_id"]}, document, upsert=True)

--- a/metldata/load/api.py
+++ b/metldata/load/api.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, Field
 from metldata.artifacts_rest.artifact_dao import ArtifactDaoCollection
 from metldata.artifacts_rest.artifact_info import get_artifact_info_dict
 from metldata.artifacts_rest.models import ArtifactInfo
+from metldata.load.aggregator import DbAggregator
 from metldata.load.auth import check_token
 from metldata.load.load import (
     ArtifactResourcesInvalid,
@@ -36,6 +37,7 @@ from metldata.load.load import (
     load_artifacts_using_dao,
 )
 from metldata.load.models import ArtifactResourceDict
+from metldata.load.summary import create_summary_using_aggregator
 
 
 class LoaderTokenAuthContext(BaseModel):
@@ -71,6 +73,7 @@ async def rest_api_factory(
     *,
     artifact_infos: list[ArtifactInfo],
     dao_factory: DaoFactoryProtocol,
+    db_aggregator: DbAggregator,
     token_hashes: list[str],
 ) -> APIRouter:
     """Return a router for an API for loading artifacts."""
@@ -113,6 +116,10 @@ async def rest_api_factory(
             artifact_resources=artifact_resources,
             artifact_info_dict=artifact_info_dict,
             dao_collection=dao_collection,
+        )
+
+        await create_summary_using_aggregator(
+            artifact_infos=artifact_info_dict, db_aggregator=db_aggregator
         )
 
         return Response(status_code=204)

--- a/metldata/load/collect.py
+++ b/metldata/load/collect.py
@@ -42,7 +42,7 @@ class ArtifactCollectorConfig(ArtifactEventConfig):
 
     # pylint: disable=no-self-argument
     @validator("artifact_types")
-    def artifact_types_must_not_cotnain_dots(cls, value: list[str]):
+    def artifact_types_must_not_contain_dots(cls, value: list[str]):
         """Validate that artifact types do not contain dots."""
 
         for artifact_type in value:

--- a/metldata/load/main.py
+++ b/metldata/load/main.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from ghga_service_commons.api import configure_app
 from hexkit.providers.mongodb import MongoDbDaoFactory
 
+from metldata.load.aggregator import MongoDbAggregator
 from metldata.load.api import rest_api_factory
 from metldata.load.config import ArtifactLoaderAPIConfig
 
@@ -33,10 +34,12 @@ async def get_app(config: ArtifactLoaderAPIConfig) -> FastAPI:
     )
     configure_app(app=app, config=config)
     dao_factory = MongoDbDaoFactory(config=config)
+    db_aggregator = MongoDbAggregator(config=config)
 
     api_router = await rest_api_factory(
         artifact_infos=config.artifact_infos,
         dao_factory=dao_factory,
+        db_aggregator=db_aggregator,
         token_hashes=config.loader_token_hashes,
     )
 

--- a/metldata/load/summary.py
+++ b/metldata/load/summary.py
@@ -23,7 +23,7 @@ from ghga_service_commons.utils.utc_dates import now_as_utc
 from metldata.artifacts_rest.models import ArtifactInfo, GlobalStats, ResourceStats
 from metldata.load.aggregator import DbAggregator
 
-SUMMARY_COLLECTION_NAME = "summary"
+STATS_COLLECTION_NAME = "stats"
 
 
 def get_stat_slot(resource_class: str) -> Optional[str]:
@@ -75,6 +75,6 @@ async def create_summary_using_aggregator(
             id="global", created=now_as_utc(), resource_stats=resource_stats
         )
         stats_dao = await db_aggregator.get_dao(
-            name="stats", dto_model=GlobalStats, id_field="id"
+            name=STATS_COLLECTION_NAME, dto_model=GlobalStats, id_field="id"
         )
         await stats_dao.upsert(global_stats)

--- a/metldata/load/summary.py
+++ b/metldata/load/summary.py
@@ -1,0 +1,77 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Generate global summary statistics."""
+
+from typing import Any, Optional
+
+from ghga_service_commons.utils.utc_dates import now_as_utc
+
+from metldata.artifacts_rest.models import ArtifactInfo
+from metldata.load.aggregator import DbAggregator
+
+SUMMARY_COLLECTION_NAME = "summary"
+
+
+def get_stat_slot(resource_class: str) -> Optional[str]:
+    """Get the name of the slot that shall be used as grouping key."""
+    if resource_class.endswith("File"):
+        return "format"
+    if resource_class.endswith("Protocol"):
+        return "type"
+    if resource_class.endswith("Individual"):
+        return "sex"
+    return None
+
+
+async def create_summary_using_aggregator(
+    artifact_infos: dict[str, ArtifactInfo],
+    db_aggregator: DbAggregator,
+) -> None:
+    """Create summary by running an aggregation pipeline on the database."""
+    summary: dict[str, Any] = {}
+    last_artifact_info = next(reversed(artifact_infos.values()))
+    last_artifact_name = last_artifact_info.name
+    for resource_class in last_artifact_info.resource_classes:
+        collection_name = f"art_{last_artifact_name}_class_{resource_class}"
+
+        pipeline: list[dict[str, Any]] = [{"$count": "count"}]
+        result = await db_aggregator.aggregate(
+            collection_name=collection_name, pipeline=pipeline
+        )
+        if not result:
+            continue
+        summary[resource_class] = result[0]
+
+        stat_slot = get_stat_slot(resource_class)
+        if not stat_slot:
+            continue
+
+        pipeline = [{"$group": {"_id": f"$content.{stat_slot}", "count": {"$sum": 1}}}]
+        result = await db_aggregator.aggregate(
+            collection_name=collection_name, pipeline=pipeline
+        )
+        if not result:
+            continue
+
+        stats = {group["_id"]: group["count"] for group in result}
+        summary[resource_class]["stats"] = {stat_slot: stats}
+
+    if summary:
+        summary.update(_id="global", created=now_as_utc())
+        await db_aggregator.write(
+            collection_name=SUMMARY_COLLECTION_NAME, document=summary
+        )

--- a/tests/load/test_main.py
+++ b/tests/load/test_main.py
@@ -29,6 +29,7 @@ from metldata.artifacts_rest.models import ArtifactInfo, GlobalStats
 from metldata.load.auth import generate_token, generate_token_and_hash
 from metldata.load.config import ArtifactLoaderAPIConfig
 from metldata.load.main import get_app
+from metldata.load.summary import STATS_COLLECTION_NAME
 from tests.fixtures.artifact_info import EXAMPLE_ARTIFACT_INFOS
 from tests.fixtures.mongodb import (  # noqa: F401; pylint: disable=unused-import
     MongoDbFixture,
@@ -130,7 +131,7 @@ async def test_load_artifacts_endpoint_happy(
     }
     dao_factory = MongoDbDaoFactory(config=mongodb_fixture.config)
     stats_dao = await dao_factory.get_dao(
-        name="stats", dto_model=GlobalStats, id_field="id"
+        name=STATS_COLLECTION_NAME, dto_model=GlobalStats, id_field="id"
     )
     async for stats in stats_dao.find_all(mapping={}):
         assert stats.id == "global"

--- a/tests/load/test_main.py
+++ b/tests/load/test_main.py
@@ -17,6 +17,7 @@
 """Test the main modules."""
 
 from copy import deepcopy
+from datetime import datetime
 
 import pytest
 from ghga_service_commons.api.testing import AsyncTestClient
@@ -24,6 +25,7 @@ from hexkit.protocols.dao import ResourceNotFoundError
 
 from metldata.artifacts_rest.artifact_dao import ArtifactDaoCollection
 from metldata.artifacts_rest.models import ArtifactInfo
+from metldata.load.aggregator import MongoDbAggregator
 from metldata.load.auth import generate_token, generate_token_and_hash
 from metldata.load.config import ArtifactLoaderAPIConfig
 from metldata.load.main import get_app
@@ -119,6 +121,25 @@ async def test_load_artifacts_endpoint_happy(
     observed_resource = await dao.get_by_id(expected_resource_id)
     assert observed_resource.content == expected_resource_content
 
+    # check that the summary statistics has been created:
+    expected_summary = {
+        "_id": "global",
+        "Dataset": {"count": 1},
+        "Sample": {"count": 2},
+        "File": {"count": 4, "stats": {"format": {"fastq": 4}}},
+        "Experiment": {"count": 1},
+    }
+    db_aggregator = MongoDbAggregator(config=mongodb_fixture.config)
+    summary_documents = await db_aggregator.aggregate(
+        collection_name="summary", pipeline=[{"$match": {}}]
+    )
+    assert len(summary_documents) == 1
+    created_summary = summary_documents[0]
+    created_date = created_summary.pop("created", None)
+    assert created_summary == expected_summary
+    assert isinstance(created_date, datetime)
+    assert abs((datetime.now() - created_date).seconds) < 5
+
     # submit an empty request:
     response = await client.post(
         "/rpc/load-artifacts",
@@ -144,7 +165,7 @@ async def test_load_artifacts_endpoint_invalid_resources(
 
     # load example artifacts resources:
     unknown_artifact_resources = {
-        "unkown_artifact": [list(EXAMPLE_ARTIFACTS.values())[0]]
+        "unknown_artifact": [list(EXAMPLE_ARTIFACTS.values())[0]]
     }
     response = await client.post(
         "/rpc/load-artifacts",


### PR DESCRIPTION
A very simple implementation of generating summary statistics and storing them in the database after the artifacts have been uploaded.

This is currently not configurable. The summary is based on the last defined artifact. It currently uses hardcoded group keys which are the same as currently used in the frontend.