### PR TITLE
Improve summary statistics and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/metldata):
 ```bash
-docker pull ghga/metldata:0.4.1
+docker pull ghga/metldata:0.4.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/metldata:0.4.1 .
+docker build -t ghga/metldata:0.4.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -76,7 +76,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/metldata:0.4.1 --help
+docker run -p 8080:8080 ghga/metldata:0.4.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/metldata/__init__.py
+++ b/metldata/__init__.py
@@ -15,4 +15,4 @@
 
 """Short description of package"""  # Please adapt to package
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/metldata/combined.py
+++ b/metldata/combined.py
@@ -41,6 +41,7 @@ async def get_app(config: Config) -> FastAPI:
 
     load_router = await load_rest_api_factory(
         artifact_infos=config.artifact_infos,
+        primary_artifact_name=config.primary_artifact_name,
         config=config,
         dao_factory=dao_factory,
         db_aggregator=db_aggregator,

--- a/metldata/load/api.py
+++ b/metldata/load/api.py
@@ -75,6 +75,7 @@ class LoaderTokenAuthProvider(AuthContextProtocol[LoaderTokenAuthContext]):
 async def rest_api_factory(
     *,
     artifact_infos: list[ArtifactInfo],
+    primary_artifact_name: str,
     config: ArtifactLoaderAPIConfig,
     dao_factory: DaoFactoryProtocol,
     db_aggregator: DbAggregator,
@@ -129,7 +130,9 @@ async def rest_api_factory(
             )
 
             await create_stats_using_aggregator(
-                artifact_infos=artifact_info_dict, db_aggregator=db_aggregator
+                artifact_infos=artifact_info_dict,
+                primary_artifact_name=primary_artifact_name,
+                db_aggregator=db_aggregator,
             )
 
             return Response(status_code=204)

--- a/metldata/load/main.py
+++ b/metldata/load/main.py
@@ -38,6 +38,7 @@ async def get_app(config: ArtifactLoaderAPIConfig) -> FastAPI:
 
     api_router = await rest_api_factory(
         artifact_infos=config.artifact_infos,
+        primary_artifact_name=config.primary_artifact_name,
         config=config,
         dao_factory=dao_factory,
         db_aggregator=db_aggregator,

--- a/metldata/load/stats.py
+++ b/metldata/load/stats.py
@@ -44,14 +44,15 @@ def get_stat_slot(resource_class: str) -> Optional[str]:
 
 async def create_stats_using_aggregator(
     artifact_infos: dict[str, ArtifactInfo],
+    primary_artifact_name: str,
     db_aggregator: DbAggregator,
 ) -> None:
     """Create summary by running an aggregation pipeline on the database."""
     resource_stats: dict[str, ResourceStats] = {}
-    last_artifact_info = next(reversed(artifact_infos.values()))
-    last_artifact_name = last_artifact_info.name
-    for resource_class in last_artifact_info.resource_classes:
-        collection_name = f"art_{last_artifact_name}_class_{resource_class}"
+    artifact_name = primary_artifact_name
+    artifact_info = artifact_infos[artifact_name]
+    for resource_class in artifact_info.resource_classes:
+        collection_name = f"art_{artifact_name}_class_{resource_class}"
 
         pipeline: list[dict[str, Any]] = [{"$count": "count"}]
         result = await db_aggregator.aggregate(

--- a/tests/artifact_rest/test_api_factory.py
+++ b/tests/artifact_rest/test_api_factory.py
@@ -137,6 +137,7 @@ async def test_get_stats_endpoint(
 
     await create_stats_using_aggregator(
         artifact_infos=get_artifact_info_dict(artifact_infos=artifact_infos),
+        primary_artifact_name=artifact_infos[-1].name,
         db_aggregator=MongoDbAggregator(config=mongodb_fixture.config),
     )
 


### PR DESCRIPTION
This PR contains two improvements:

- Instead of guessing the name of the artifact for the summary statistics, use the newly introduced config setting.
- Show a detailed error message when there is an error during the aggregation transformation.