### PR TITLE
Sort lists by value in individual and global stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/metldata):
 ```bash
-docker pull ghga/metldata:0.4.2
+docker pull ghga/metldata:0.4.3
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/metldata:0.4.2 .
+docker build -t ghga/metldata:0.4.3 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -76,7 +76,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/metldata:0.4.2 --help
+docker run -p 8080:8080 ghga/metldata:0.4.3 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/metldata/__init__.py
+++ b/metldata/__init__.py
@@ -15,4 +15,4 @@
 
 """Short description of package"""  # Please adapt to package
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/metldata/builtin_transformations/aggregate/func.py
+++ b/metldata/builtin_transformations/aggregate/func.py
@@ -18,6 +18,7 @@
 
 from abc import ABC, abstractmethod
 from collections import Counter
+from operator import itemgetter
 from typing import Any, Iterable, Optional
 
 from metldata.builtin_transformations.aggregate.models import (
@@ -146,10 +147,13 @@ class StringElementCountAggregation(ElementCountAggregation):
 
     @classmethod
     def func(cls, data: Iterable[Any]) -> list[dict[str, Any]]:
-        return [
-            {"value": str(value), "count": count}
-            for value, count in Counter(data).items()
-        ]
+        return sorted(
+            (
+                {"value": "unknown" if value is None else str(value), "count": count}
+                for value, count in Counter(data).items()
+            ),
+            key=itemgetter("value"),
+        )
 
 
 @register_function
@@ -167,10 +171,14 @@ class IntegerElementCountAggregation(ElementCountAggregation):
 
     @classmethod
     def func(cls, data: Iterable[Any]) -> list[dict[str, Any]]:
-        return [
-            {"value": int(value), "count": count}
-            for value, count in Counter(data).items()
-        ]
+        return sorted(
+            (
+                {"value": int(value), "count": count}
+                for value, count in Counter(data).items()
+                if value is not None
+            ),
+            key=itemgetter("value"),
+        )
 
 
 def transformation_by_name(name: str) -> type[AggregationFunction]:

--- a/metldata/load/stats.py
+++ b/metldata/load/stats.py
@@ -16,6 +16,7 @@
 
 """Generate global summary statistics."""
 
+from operator import itemgetter
 from typing import Any, Optional, cast
 
 from ghga_service_commons.utils.utc_dates import now_as_utc
@@ -73,10 +74,13 @@ async def create_stats_using_aggregator(
         if not result:
             continue
 
-        stats: list[ValueCount] = [
-            {"value": group["_id"] or "unknown", "count": group["count"]}
-            for group in result
-        ]
+        stats: list[ValueCount] = sorted(
+            (
+                {"value": group["_id"] or "unknown", "count": group["count"]}
+                for group in result
+            ),
+            key=itemgetter("value"),
+        )
         resource_stats[resource_class]["stats"] = {stat_slot: stats}
 
     if resource_stats:


### PR DESCRIPTION
Sort the value/cont-lists in the dataset summary stats and global summary stats by value.

These lists then do not need to be sorted in the frontend and we get stable responses for testing.