### PR TITLE
Update pypi_publish script

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -8,17 +8,18 @@ jobs:
   pypi-publish:
     name: Publish tagged release on PyPI
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
-      - name: Verify Package Version vs Tag Version
+      - name: Ensure package version and tag name are equal
         run: |
-          PKG_VER="$(grep -oP 'version = \"\K[^\"]+' pyproject.toml)"
+          PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2
@@ -46,7 +47,7 @@ jobs:
       - name: Install the newly build package with all extras
         run: |
           TAR_PATH="$( realpath ./dist/*.tar.gz)"
-          python -m \
+          python3 -m \
             pip install \
             "${TAR_PATH}[all]"
 
@@ -54,9 +55,9 @@ jobs:
         run: >-
           python -m
           pip install
-          -r requirements-dev.txt
+          --no-deps -r ./lock/requirements-dev.txt
 
-      - name: Run pytest on freshly installed package
+      - name: Run pytest on freshly install package
         run: |
           pytest .
 


### PR DESCRIPTION
Fix the script to reflect the lock file location, as well as update the project version regex so it doesn't get hung up on the other uses of 'version' in pyproject.toml