### PR TITLE
property is added to the schema through count references transformation

### DIFF
--- a/src/metldata/builtin_transformations/add_content_properties/model_transform.py
+++ b/src/metldata/builtin_transformations/add_content_properties/model_transform.py
@@ -47,7 +47,7 @@ def add_content_properties(
 
         for cls_instruction in cls_instructions:
             try:
-                target_object = resolve_schema_object_path(
+                target_schema = resolve_schema_object_path(
                     content_schema, cls_instruction.target_content.object_path
                 )
             except KeyError as e:
@@ -58,12 +58,12 @@ def add_content_properties(
             ):
                 raise EvitableTransformationError()
 
-            target_object.setdefault("properties", {})[
+            target_schema.setdefault("properties", {})[
                 cls_instruction.target_content.property_name
             ] = deepcopy(cls_instruction.content_schema)
 
             if cls_instruction.required:
-                target_object.setdefault("required", []).append(
+                target_schema.setdefault("required", []).append(
                     cls_instruction.target_content.property_name
                 )
 

--- a/src/metldata/builtin_transformations/count_references/assumptions.py
+++ b/src/metldata/builtin_transformations/count_references/assumptions.py
@@ -165,10 +165,8 @@ def assert_object_path_exists(
             + f" in class {class_name}."
         ) from exc
 
-    # Check if the propert_name already exists in the model
-    if instruction.target_content.property_name not in target_schema.get(
-        "properties", {}
-    ):
+    # Check if the propert_name already exists in the model and raise an error if so
+    if instruction.target_content.property_name in target_schema.get("properties", {}):
         raise ModelAssumptionError(
             f"Property {
                 instruction.target_content.property_name} does not exist"

--- a/tests/fixtures/example_transformations/count_references/multiple/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/count_references/multiple/input.datapack.yaml
@@ -23,8 +23,7 @@ resources:
     dataset_1:
       content:
         dac_contact: dac@example.org
-        file_summary: # <-
-          count: 0
+        file_summary: {} # <-
       relations:
         files:
           - file_a
@@ -34,24 +33,21 @@ resources:
     sample_x:
       content:
         description: Some sample.
-        file_summary: # <-
-          count: 0
+        file_summary: {} # <-
       relations:
         files:
           - file_a
           - file_b
     sample_y:
       content:
-        file_summary: # <-
-          count: 0
+        file_summary: {} # <-
       relations:
         files:
           - file_c
   Experiment:
     experiment_i:
       content:
-        sample_summary: # <-
-          count: 0
+        sample_summary: {} # <-
       relations:
         samples:
           - sample_x

--- a/tests/fixtures/example_transformations/count_references/multiple/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/count_references/multiple/input.schemapack.yaml
@@ -16,13 +16,7 @@ classes:
         "properties":
           {
             "dac_contact": { "type": "string" },
-            "file_summary":
-              {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": { "count": { "type": "integer" } },
-                "required": ["count"],
-              },
+            "file_summary": { "type": "object", "additionalProperties": true },
           },
         "type": "object",
       }
@@ -46,13 +40,7 @@ classes:
         "properties":
           {
             "description": { "type": "string" },
-            "file_summary":
-              {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": { "count": { "type": "integer" } },
-                "required": ["count"],
-              },
+            "file_summary": { "type": "object", "additionalProperties": true },
           },
         "type": "object",
       }
@@ -77,12 +65,7 @@ classes:
           {
             "description": { "type": "string" },
             "sample_summary":
-              {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": { "count": { "type": "integer" } },
-                "required": ["count"],
-              },
+              { "type": "object", "additionalProperties": true },
           },
         "type": "object",
       }

--- a/tests/fixtures/example_transformations/count_references/multiple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/count_references/multiple/transformed.schemapack.yaml
@@ -19,9 +19,8 @@ classes:
             "file_summary":
               {
                 "type": "object",
-                "additionalProperties": false,
+                "additionalProperties": true,
                 "properties": { "count": { "type": "integer" } },
-                "required": ["count"],
               },
           },
         "type": "object",
@@ -49,9 +48,8 @@ classes:
             "file_summary":
               {
                 "type": "object",
-                "additionalProperties": false,
+                "additionalProperties": true,
                 "properties": { "count": { "type": "integer" } },
-                "required": ["count"],
               },
           },
         "type": "object",
@@ -79,9 +77,8 @@ classes:
             "sample_summary":
               {
                 "type": "object",
-                "additionalProperties": false,
+                "additionalProperties": true,
                 "properties": { "count": { "type": "integer" } },
-                "required": ["count"],
               },
           },
         "type": "object",


### PR DESCRIPTION
 The `object_path`(given in the config for this transformation) will be added by the `add_content_properties` transformation. However, the `property_name` will not be included in that transformation. As a result, if the `property_name` exists in the pre-transformed model, it should fail the model assumptions. The `property_name` needs to be added during the model transformation phase of `count_references`.

This PR introduces a fix to model transformation based on the requirements explained above. 