### PR TITLE
Nested schema support on content path

### DIFF
--- a/src/metldata/builtin_transformations/common/assumptions/source_assumptions.py
+++ b/src/metldata/builtin_transformations/common/assumptions/source_assumptions.py
@@ -17,6 +17,9 @@
 
 from schemapack.spec.schemapack import SchemaPack
 
+from metldata.builtin_transformations.add_content_properties.path import (
+    resolve_schema_object_path,
+)
 from metldata.builtin_transformations.common.instruction import (
     InstructionProtocol,
     SourceInstructionProtocol,
@@ -57,7 +60,7 @@ def assert_source_content_path_exists(
             f"Class {referenced_class} does not exist in the model."
         )
 
-    content_slot = class_def.content["properties"].get(content_path)
+    content_slot = resolve_schema_object_path(class_def.content, content_path)
 
     if not content_slot:
         raise ModelAssumptionError(

--- a/src/metldata/builtin_transformations/common/data_transform.py
+++ b/src/metldata/builtin_transformations/common/data_transform.py
@@ -153,9 +153,12 @@ def get_source_values(
     content_path: str,
 ) -> list[Any]:
     """Get countable properties from all resources referred to by the relation."""
+    # Schema that includes the property that is of interest.
     try:
         return [
-            referenced_resources[resource_id]["content"].get(content_path)
+            resolve_data_object_path(
+                referenced_resources[resource_id]["content"], content_path
+            )
             for resource_id in relation_target_ids
         ]
     except KeyError as exc:

--- a/src/metldata/builtin_transformations/common/data_transform.py
+++ b/src/metldata/builtin_transformations/common/data_transform.py
@@ -153,7 +153,6 @@ def get_source_values(
     content_path: str,
 ) -> list[Any]:
     """Get countable properties from all resources referred to by the relation."""
-    # Schema that includes the property that is of interest.
     try:
         return [
             resolve_data_object_path(

--- a/src/metldata/builtin_transformations/sum_operation/assumptions.py
+++ b/src/metldata/builtin_transformations/sum_operation/assumptions.py
@@ -17,6 +17,9 @@
 
 from schemapack.spec.schemapack import SchemaPack
 
+from metldata.builtin_transformations.add_content_properties.path import (
+    resolve_schema_object_path,
+)
 from metldata.builtin_transformations.common.assumptions import (
     assert_class_is_source,
     assert_object_path_exists,
@@ -66,7 +69,7 @@ def assert_countable_data_type(
             f"Class {referenced_class} does not exist in the model."
         )
 
-    content_slot = class_def.content["properties"].get(content_path)
+    content_slot = resolve_schema_object_path(class_def.content, content_path)
 
     if content_slot["type"] not in {"integer", "number", "boolean"}:
         raise ModelAssumptionError(

--- a/tests/fixtures/example_transformations/copy_content/simple/config.yaml
+++ b/tests/fixtures/example_transformations/copy_content/simple/config.yaml
@@ -1,22 +1,22 @@
 copy_content:
   - class_name: File
-    source:
-      relation_path: File<(files)Dataset
-      content_path: dac_contact
     target_content:
       property_name: dac_contact
       object_path: dataset_information
-  - class_name: Sample
     source:
-      relation_path: Sample(files)>File
-      content_path: filename
+      relation_path: File<(files)Dataset
+      content_path: dac_contact
+  - class_name: Sample
     target_content:
       property_name: referenced_filename
       object_path: ""
-  - class_name: Sample
     source:
-      relation_path: Sample(files)>File<(files)Dataset
-      content_path: dac_contact
+      relation_path: Sample(files)>File
+      content_path: file_info.filename
+  - class_name: Sample
     target_content:
       property_name: dac_contact
       object_path: ""
+    source:
+      relation_path: Sample(files)>File<(files)Dataset
+      content_path: dac_contact

--- a/tests/fixtures/example_transformations/copy_content/simple/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/copy_content/simple/input.datapack.yaml
@@ -3,21 +3,24 @@ resources:
   File:
     file_a:
       content:
-        filename: file_a.fastq
+        file_info:
+          filename: file_a.fastq
         format: FASTQ
         checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
         size: 12321
         dataset_information: {}
     file_b:
       content:
-        filename: file_b.fastq
+        file_info:
+          filename: file_b.fastq
         format: FASTQ
         checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
         size: 12314
         dataset_information: {}
     file_c:
       content:
-        filename: file_c.fastq
+        file_info:
+          filename: file_c.fastq
         format: FASTQ
         checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
         size: 12123

--- a/tests/fixtures/example_transformations/copy_content/simple/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/copy_content/simple/input.schemapack.yaml
@@ -12,17 +12,19 @@ classes:
         "properties":
           {
             "checksum": { "type": "string" },
-            "filename": { "type": "string" },
+            "file_info":
+              {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": { "filename": { "type": "string" } },
+              },
             "format": { "type": "string" },
             "size": { "type": "integer" },
             "dataset_information":
-            {
-              "additionalProperties": false,
-              "type": "object",
-            },
+              { "additionalProperties": false, "type": "object" },
           },
         "required":
-          ["filename", "format", "checksum", "size", "dataset_information"],
+          ["file_info", "format", "checksum", "size", "dataset_information"],
         "type": "object",
       }
   Dataset:

--- a/tests/fixtures/example_transformations/copy_content/simple/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/copy_content/simple/transformed.datapack.yaml
@@ -3,7 +3,8 @@ resources:
   File:
     file_a:
       content:
-        filename: file_a.fastq
+        file_info:
+          filename: file_a.fastq
         format: FASTQ
         checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
         size: 12321
@@ -11,7 +12,8 @@ resources:
           dac_contact: dac@example.org # <-
     file_b:
       content:
-        filename: file_b.fastq
+        file_info:
+          filename: file_b.fastq
         format: FASTQ
         checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
         size: 12314
@@ -19,7 +21,8 @@ resources:
           dac_contact: dac@example.org # <-
     file_c:
       content:
-        filename: file_c.fastq
+        file_info:
+          filename: file_c.fastq
         format: FASTQ
         checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
         size: 12123

--- a/tests/fixtures/example_transformations/copy_content/simple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/copy_content/simple/transformed.schemapack.yaml
@@ -55,7 +55,7 @@ classes:
             "description": { "type": "string" },
             "dac_contact": { "type": "string" },
             "referenced_filename": { "type": "string" },
-          }, # <- # <-
+          }, # <-
         "type": "object",
       }
     relations:

--- a/tests/fixtures/example_transformations/copy_content/simple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/copy_content/simple/transformed.schemapack.yaml
@@ -12,21 +12,22 @@ classes:
         "properties":
           {
             "checksum": { "type": "string" },
-            "filename": { "type": "string" },
+            "file_info":
+              {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": { "filename": { "type": "string" } },
+              },
             "format": { "type": "string" },
             "size": { "type": "integer" },
-            "dataset_information":
-            {
-              "additionalProperties": false,
-              "properties":
-              {
-                "dac_contact": { "type": "string" } # <-
-              },
-              "type": "object",
-            },
+            "dataset_information": {
+                "additionalProperties": false,
+                "properties": { "dac_contact": { "type": "string" } },
+                "type": "object",
+              }, # <-
           },
         "required":
-          ["filename", "format", "checksum", "size", "dataset_information"],
+          ["file_info", "format", "checksum", "size", "dataset_information"],
         "type": "object",
       }
   Dataset:
@@ -51,11 +52,11 @@ classes:
         "additionalProperties": false,
         "description": "A sample used to generate files in the context of an experiment.",
         "properties": {
-          "description": {"type": "string"},
-          "dac_contact": {"type": "string"}, # <-
-          "referenced_filename": {"type": "string"}, # <-
-        },
-        "type": "object"
+            "description": { "type": "string" },
+            "dac_contact": { "type": "string" },
+            "referenced_filename": { "type": "string" },
+          }, # <- # <-
+        "type": "object",
       }
     relations:
       files:

--- a/tests/fixtures/example_transformations/count_content_values/single/config.yaml
+++ b/tests/fixtures/example_transformations/count_content_values/single/config.yaml
@@ -5,4 +5,4 @@ count_content_values:
       property_name: description
     source:
       relation_path: Dataset(files)>File(samples)>Sample
-      content_path: description
+      content_path: biomaterial.description

--- a/tests/fixtures/example_transformations/count_content_values/single/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/count_content_values/single/input.datapack.yaml
@@ -38,10 +38,13 @@ resources:
   Sample:
     sample_a:
       content:
-        description: tissue
+        biomaterial:
+          description: tissue
     sample_b:
       content:
-        description: blood
+        biomaterial:
+          description: blood
     sample_c:
       content:
-        description: tissue
+        biomaterial:
+          description: tissue

--- a/tests/fixtures/example_transformations/count_content_values/single/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/count_content_values/single/input.schemapack.yaml
@@ -51,4 +51,19 @@ classes:
   Sample:
     id:
       propertyName: alias
-    content: ../../../example_content_schemas/Sample.schema.json
+    content:
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "description": "A sample.",
+        "properties":
+          {
+            "biomaterial":
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "description": { "type": "string" } },
+              },
+          },
+        "type": "object",
+      }

--- a/tests/fixtures/example_transformations/count_content_values/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/count_content_values/single/transformed.datapack.yaml
@@ -42,10 +42,13 @@ resources:
   Sample:
     sample_a:
       content:
-        description: tissue
+        biomaterial:
+          description: tissue
     sample_b:
       content:
-        description: blood
+        biomaterial:
+          description: blood
     sample_c:
       content:
-        description: tissue
+        biomaterial:
+          description: tissue

--- a/tests/fixtures/example_transformations/count_content_values/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/count_content_values/single/transformed.schemapack.yaml
@@ -63,4 +63,19 @@ classes:
   Sample:
     id:
       propertyName: alias
-    content: ../../../example_content_schemas/Sample.schema.json
+    content:
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "description": "A sample.",
+        "properties":
+          {
+            "biomaterial":
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "description": { "type": "string" } },
+              },
+          },
+        "type": "object",
+      }

--- a/tests/fixtures/example_transformations/sum_operation/single/config.yaml
+++ b/tests/fixtures/example_transformations/sum_operation/single/config.yaml
@@ -6,3 +6,10 @@ sum_operation:
     source:
       relation_path: Dataset(files)>File
       content_path: size
+  - class_name: Dataset
+    target_content:
+      object_path: file_summary.stats
+      property_name: submitted_files
+    source:
+      relation_path: Dataset(files)>File
+      content_path: submission.included

--- a/tests/fixtures/example_transformations/sum_operation/single/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/sum_operation/single/input.datapack.yaml
@@ -18,15 +18,21 @@ resources:
         format: FASTQ
         checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
         size: 12321
+        submission:
+          included: false
     file_b:
       content:
         filename: file_b.fastq
         format: FASTQ
         checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
         size: 12314
+        submission:
+          included: true
     file_c:
       content:
         filename: file_c.fastq
         format: FASTQ
         checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
         size: 12123
+        submission:
+          included: true

--- a/tests/fixtures/example_transformations/sum_operation/single/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/sum_operation/single/input.schemapack.yaml
@@ -38,4 +38,24 @@ classes:
   File:
     id:
       propertyName: alias
-    content: ../../../example_content_schemas/File.schema.json
+    content:
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "description": "A file is an object that contains information generated from a process, either an Experiment or an Analysis.",
+        "properties":
+          {
+            "checksum": { "type": "string" },
+            "filename": { "type": "string" },
+            "format": { "type": "string" },
+            "size": { "type": "integer" },
+            "submission":
+              {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": { "included": { "type": "boolean" } },
+              },
+          },
+        "required": ["filename", "format", "checksum", "size"],
+        "type": "object",
+      }

--- a/tests/fixtures/example_transformations/sum_operation/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/sum_operation/single/transformed.datapack.yaml
@@ -7,6 +7,7 @@ resources:
         file_summary:
           stats:
             size: 36758 # <-
+            submitted_files: 2 # <-
       relations:
         files:
           - file_a
@@ -19,15 +20,21 @@ resources:
         format: FASTQ
         checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
         size: 12321
+        submission:
+          included: false
     file_b:
       content:
         filename: file_b.fastq
         format: FASTQ
         checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
         size: 12314
+        submission:
+          included: true
     file_c:
       content:
         filename: file_c.fastq
         format: FASTQ
         checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
         size: 12123
+        submission:
+          included: true

--- a/tests/fixtures/example_transformations/sum_operation/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/sum_operation/single/transformed.schemapack.yaml
@@ -22,7 +22,11 @@ classes:
                       {
                         "type": "object",
                         "additionalProperties": true,
-                        "properties": { "size": { "type": "number" } },
+                        "properties":
+                          {
+                            "size": { "type": "number" },
+                            "submitted_files": { "type": "number" },
+                          },
                       },
                   },
                 "required": ["stats"],
@@ -43,4 +47,24 @@ classes:
   File:
     id:
       propertyName: alias
-    content: ../../../example_content_schemas/File.schema.json
+    content:
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "description": "A file is an object that contains information generated from a process, either an Experiment or an Analysis.",
+        "properties":
+          {
+            "checksum": { "type": "string" },
+            "filename": { "type": "string" },
+            "format": { "type": "string" },
+            "size": { "type": "integer" },
+            "submission":
+              {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": { "included": { "type": "boolean" } },
+              },
+          },
+        "required": ["filename", "format", "checksum", "size"],
+        "type": "object",
+      }


### PR DESCRIPTION
This PR introduces data and model transformation fixes to support dotted nomenclature on `content_path` for `count_content_values`, `sum_operations`, and `copy_operation`. 