### PR TITLE
Refactor workflow loop

### DIFF
--- a/src/metldata/workflow/template_utils.py
+++ b/src/metldata/workflow/template_utils.py
@@ -23,12 +23,12 @@ from jinja2.sandbox import ImmutableSandboxedEnvironment
 # Random string, effectively disabling Jinja2 blocks and comments
 RANDOM_START_END_STRING = "Wk4CPM:"
 env = ImmutableSandboxedEnvironment(
-    block_start_string=RANDOM_START_END_STRING,
-    block_end_string=RANDOM_START_END_STRING,
+    block_start_string=RANDOM_START_END_STRING + "A",
+    block_end_string=RANDOM_START_END_STRING + "B",
     variable_start_string="{{{",
     variable_end_string="}}}",
-    comment_start_string=RANDOM_START_END_STRING,
-    comment_end_string=RANDOM_START_END_STRING,
+    comment_start_string=RANDOM_START_END_STRING + "C",
+    comment_end_string=RANDOM_START_END_STRING + "D",
 )
 
 

--- a/src/metldata/workflow/template_utils.py
+++ b/src/metldata/workflow/template_utils.py
@@ -20,13 +20,15 @@ from typing import Any
 
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
+# Random string, effectively disabling Jinja2 blocks and comments
+RANDOM_START_END_STRING = "Wk4CPM:"
 env = ImmutableSandboxedEnvironment(
-    block_start_string="Wk4CPM:1",  # Random, effectively disabling Jinja2 blocks
-    block_end_string=":Wk4CPM:1",  # Random, effectively disabling Jinja2 blocks
+    block_start_string=RANDOM_START_END_STRING,
+    block_end_string=RANDOM_START_END_STRING,
     variable_start_string="{{{",
     variable_end_string="}}}",
-    comment_start_string="Wk4CPM",  # Random, effectively disabling Jinja2 comments
-    comment_end_string=":Wk4CPM",  # Random, effectively disabling Jinja2 comments
+    comment_start_string=RANDOM_START_END_STRING,
+    comment_end_string=RANDOM_START_END_STRING,
 )
 
 

--- a/tests/fixtures/example_workflows/add_multiple_content_properties/workflow.yaml
+++ b/tests/fixtures/example_workflows/add_multiple_content_properties/workflow.yaml
@@ -2,10 +2,10 @@ operations:
 - name: transform_content
   description: "Add a new propery to the content of {{ class_name }}"
   args:
-    class_name: "{{ class_name }}"
-    content_schema: "{{ content_schema }}"
-    embedding_profile: "{{ embedding_profile }}"
-    data_template: "{{ data_template }}"
+    class_name: "{{{ item.class_name }}}"
+    content_schema: "{{{ item.content_schema }}}"
+    embedding_profile: "{{{ item.embedding_profile }}}"
+    data_template: "{{{ item.data_template }}}"
   loop:
     - class_name: File
       content_schema: {

--- a/tests/fixtures/example_workflows/count_references/workflow.yaml
+++ b/tests/fixtures/example_workflows/count_references/workflow.yaml
@@ -3,9 +3,9 @@ operations:
   - name: infer_relation
     description: "Infer {{ relation_name }} for each Dataset"
     args:
-      class_name: "{{ class_name }}"
-      relation_name: "{{ relation_name }}"
-      relation_path: "{{ relation_path }}"
+      class_name: "{{{ item.class_name }}}"
+      relation_name: "{{{ item.relation_name }}}"
+      relation_path: "{{{ item.relation_path }}}"
     loop:
       - class_name: Dataset
         relation_name: samples
@@ -16,10 +16,10 @@ operations:
   - name: transform_content
     description: "Count references for {{ class_name }}"
     args:
-      class_name: "{{ class_name }}"
-      content_schema: "{{ content_schema }}"
-      embedding_profile: "{{ embedding_profile }}"
-      data_template: "{{ data_template }}"
+      class_name: "{{{ item.class_name }}}"
+      content_schema: "{{{ item.content_schema }}}"
+      embedding_profile: "{{{ item.embedding_profile }}}"
+      data_template: "{{{ item.data_template }}}"
     loop:
       - class_name: Dataset
         content_schema: {

--- a/tests/fixtures/example_workflows/delete_multiple/workflow.yaml
+++ b/tests/fixtures/example_workflows/delete_multiple/workflow.yaml
@@ -3,7 +3,7 @@ operations:
   - name: delete_class
     description: "Delete class {{ item }}"
     args:
-      class_name: "{{ item }}"
+      class_name: "{{{ item }}}"
     loop:
       - Dataset
       - Sample

--- a/tests/fixtures/example_workflows/duplicate_multiple_delete_one/workflow.yaml
+++ b/tests/fixtures/example_workflows/duplicate_multiple_delete_one/workflow.yaml
@@ -3,8 +3,8 @@ operations:
   - name: duplicate_class
     description: "Create a duplicate of class {{ source_class_name }} named {{ target_class_name }}"
     args:
-      source_class_name: "{{ source_class_name }}"
-      target_class_name: "{{ target_class_name }}"
+      source_class_name: "{{{ item.source_class_name }}}"
+      target_class_name: "{{{ item.target_class_name }}}"
     loop:
       - source_class_name: Dataset
         target_class_name: MyDataset

--- a/tests/fixtures/example_workflows/duplicate_multiple_delete_one_embed_relation/workflow.yaml
+++ b/tests/fixtures/example_workflows/duplicate_multiple_delete_one_embed_relation/workflow.yaml
@@ -3,8 +3,8 @@ operations:
   - name: duplicate_class
     description: "Create a duplicate of class {{ source_class_name }} named {{ target_class_name }}"
     args:
-      source_class_name: "{{ source_class_name }}"
-      target_class_name: "{{ target_class_name }}"
+      source_class_name: "{{{ item.source_class_name }}}"
+      target_class_name: "{{{ item.target_class_name }}}"
     loop:
       - source_class_name: Dataset
         target_class_name: MyDataset

--- a/tests/fixtures/example_workflows/duplicate_one_delete_multiple/workflow.yaml
+++ b/tests/fixtures/example_workflows/duplicate_one_delete_multiple/workflow.yaml
@@ -7,9 +7,9 @@ operations:
       target_class_name: MyDataset
   # Delete classes - this will automatically delete the obsolete relations
   - name: delete_class
-    description: "Delete class {{ item }}"
+    description: "Delete class {{{ item }}}"
     args:
-      class_name: "{{ item }}"
+      class_name: "{{{ item }}}"
     loop:
       - Dataset
       - Sample

--- a/tests/fixtures/example_workflows/infer_multiple/workflow.yaml
+++ b/tests/fixtures/example_workflows/infer_multiple/workflow.yaml
@@ -11,8 +11,8 @@ operations:
     description: "Infer {{ relation_name }} for each FileSummary"
     args:
       class_name: FileSummary
-      relation_name: "{{ relation_name }}"
-      relation_path: "{{ relation_path }}"
+      relation_name: "{{{ item.relation_name }}}"
+      relation_path: "{{{ item.relation_path }}}"
     loop:
       - relation_name: datasets
         relation_path: FileSummary<(files)Dataset


### PR DESCRIPTION
This patch address three problems in the current implementation of the loop feature in the workflow implementation that partially arose in the context of this transformation:

* **Problem 1: Loop templating on re-serialized workflow steps is not a good idea**

  * Before  
    * Deserialize Yaml Workflow  
    * Serialize single step (JSON)  
    * Jinja2 Rendering  
    * Deserialize single step

  * After  
    * Deserialize Yaml Workflow  
    * Dump to dict (mode=’json’)  
    * Recursively Jinja2 render all strings in dict  
    * Load back into Pydantic model (`model_validate`)

* **Problem 2: Nested Templates were not supported**

    ```
    - name: transform_content
      description: foobar
      args:
      class_name: {{ item }}
      data_template: |+
        {% for key, value in original.items() %}
        {% if key != "additional_information" %}
        {{ key }}: {{ value }}
        {% endif %}
        {% endfor %}
        additional_information:
          compression: false
    ```
    Solution: Configure Jinja2 environment for `item` injection differently

* **Problem 3: `item` was not implemented [as specified in the epic spec](https://github.com/ghga-de/epic-docs/blob/main/71-carpenter-bee/technical_specification.md#workflow-language), the name was only used in some cases**

  
