### PR TITLE
rename id property transformation

### DIFF
--- a/src/metldata/builtin_transformations/rename_id_property/__init__.py
+++ b/src/metldata/builtin_transformations/rename_id_property/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A transformation to change the name of the id property in the model of a given class."""
+
+from metldata.builtin_transformations.rename_id_property.main import (  # noqa: F401
+    RENAME_ID_PROPERTY_TRANSFORMATION,
+)

--- a/src/metldata/builtin_transformations/rename_id_property/assumptions.py
+++ b/src/metldata/builtin_transformations/rename_id_property/assumptions.py
@@ -1,0 +1,46 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"Assumptions for the `rename id property` transformation"
+
+from schemapack.spec.schemapack import SchemaPack
+
+from metldata.builtin_transformations.common.assumptions.path_assumptions import (
+    check_class_exists,
+)
+from metldata.transform.exceptions import ModelAssumptionError
+
+
+def check_model_assumptions(
+    model: SchemaPack, class_name: str, new_id_property: str
+) -> None:
+    """Check model assumptions for the `rename id property` transformation."""
+    check_class_exists(model=model, class_name=class_name)
+    check_id_is_different_from_existing(
+        model=model,
+        class_name=class_name,
+        new_id_property=new_id_property,
+    )
+
+
+def check_id_is_different_from_existing(
+    model: SchemaPack, class_name: str, new_id_property: str
+) -> None:
+    """Check that the current id is not the same as the new one."""
+    existing_id_property = model.classes[class_name].id.propertyName
+    if existing_id_property == new_id_property:
+        raise ModelAssumptionError(
+            f"The id property '{new_id_property}' already exists in the model."
+        )

--- a/src/metldata/builtin_transformations/rename_id_property/config.py
+++ b/src/metldata/builtin_transformations/rename_id_property/config.py
@@ -13,21 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
-# for the German Human Genome-Phenome Archive (GHGA)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """Models for instructions used in the 'rename id property' transformation."""
 
 from pydantic import Field

--- a/src/metldata/builtin_transformations/rename_id_property/config.py
+++ b/src/metldata/builtin_transformations/rename_id_property/config.py
@@ -1,0 +1,50 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Models for instructions used in the 'rename id property' transformation."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class RenameIdPropertyConfig(BaseSettings):
+    """A model describing a configuration for renaming model's id property."""
+
+    class_name: str = Field(
+        default=...,
+        description="The name of the class whose id property will be renamed.",
+    )
+    id_property_name: str = Field(
+        default=..., description="The name of the new id property."
+    )
+    description: str | None = Field(
+        default=None,
+        description="A description of the id property name.",
+    )

--- a/src/metldata/builtin_transformations/rename_id_property/data_transform.py
+++ b/src/metldata/builtin_transformations/rename_id_property/data_transform.py
@@ -1,0 +1,23 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data transformation logic for the `rename id property` transformation"""
+
+from schemapack.spec.datapack import DataPack
+
+
+def rename_data_id_property(*, data: DataPack) -> DataPack:
+    """Return data as it is, since id property name is not a part of DataPack."""
+    return data

--- a/src/metldata/builtin_transformations/rename_id_property/main.py
+++ b/src/metldata/builtin_transformations/rename_id_property/main.py
@@ -1,0 +1,96 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A transformation to modify the content schema and data of a given class."""
+
+from schemapack.spec.datapack import DataPack
+from schemapack.spec.schemapack import SchemaPack
+
+from metldata.builtin_transformations.rename_id_property.assumptions import (
+    check_model_assumptions,
+)
+from metldata.builtin_transformations.rename_id_property.config import (
+    RenameIdPropertyConfig,
+)
+from metldata.builtin_transformations.rename_id_property.data_transform import (
+    rename_data_id_property,
+)
+from metldata.builtin_transformations.rename_id_property.model_transform import (
+    rename_model_id_property,
+)
+from metldata.transform.base import (
+    DataTransformer,
+    SubmissionAnnotation,
+    TransformationDefinition,
+)
+
+
+class RenameIdPropertyTransformer(
+    DataTransformer[RenameIdPropertyConfig, SubmissionAnnotation]
+):
+    """A transformer that does not apply any changes to data since the id property name
+    is not a part of a DataPack.
+    """
+
+    def transform(self, data: DataPack, annotation: SubmissionAnnotation) -> DataPack:
+        """Transforms data.
+
+        Args:
+            data: The data as DataPack to be transformed.
+
+        Raises:
+            DataTransformationError:
+                if the transformation fails.
+        """
+        return rename_data_id_property(data=data)
+
+
+def check_model_assumptions_wrapper(
+    model: SchemaPack, config: RenameIdPropertyConfig
+) -> None:
+    """Check the assumptions of the model.
+
+    Raises:
+        ModelAssumptionError:
+            if the model does not fulfill the assumptions.
+    """
+    check_model_assumptions(
+        model=model,
+        class_name=config.class_name,
+        new_id_property=config.id_property_name,
+    )
+
+
+def transform_model(model: SchemaPack, config: RenameIdPropertyConfig) -> SchemaPack:
+    """Transform the data model.
+
+    Raises:
+        DataModelTransformationError:
+            if the transformation fails.
+    """
+    return rename_model_id_property(
+        model=model,
+        class_name=config.class_name,
+        id_property_name=config.id_property_name,
+        description=config.description,
+    )
+
+
+RENAME_ID_PROPERTY_TRANSFORMATION = TransformationDefinition[RenameIdPropertyConfig](
+    config_cls=RenameIdPropertyConfig,
+    check_model_assumptions=check_model_assumptions_wrapper,
+    transform_model=transform_model,
+    data_transformer_factory=RenameIdPropertyTransformer,
+)

--- a/src/metldata/builtin_transformations/rename_id_property/model_transform.py
+++ b/src/metldata/builtin_transformations/rename_id_property/model_transform.py
@@ -1,0 +1,40 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model transformation logic for the 'rename id property' transformation"""
+
+from schemapack.spec.schemapack import IDSpec, SchemaPack
+
+from metldata.builtin_transformations.common.utils import model_to_dict
+from metldata.transform.exceptions import EvitableTransformationError
+
+
+def rename_model_id_property(
+    *,
+    model: SchemaPack,
+    class_name: str,
+    id_property_name: str,
+    description: str | None,
+) -> SchemaPack:
+    """Rename the id property of the model."""
+    mutable_model = model_to_dict(model)
+    try:
+        mutable_model["classes"][class_name]["id"] = IDSpec(
+            propertyName=id_property_name,
+            description=description,
+        )
+    except KeyError as exc:
+        raise EvitableTransformationError() from exc
+    return SchemaPack.model_validate(mutable_model)

--- a/tests/fixtures/example_transformations/rename_id_property/single/config.yaml
+++ b/tests/fixtures/example_transformations/rename_id_property/single/config.yaml
@@ -1,0 +1,3 @@
+class_name: File
+id_property_name: ghga_accession
+description: File identifier assigned by GHGA.

--- a/tests/fixtures/example_transformations/rename_id_property/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/rename_id_property/single/transformed.datapack.yaml
@@ -1,0 +1,58 @@
+datapack: 0.3.0
+resources:
+  File:
+    file_a:
+      content:
+        filename: file_a.fastq
+        format: FASTQ
+        checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
+        size: 12321
+    file_b:
+      content:
+        filename: file_b.fastq
+        format: FASTQ
+        checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
+        size: 12314
+    file_c:
+      content:
+        filename: file_c.fastq
+        format: FASTQ
+        checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
+        size: 12123
+  Dataset:
+    dataset_1:
+      content:
+        dac_contact: dac@example.org
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+            - file_c
+  Sample:
+    sample_x:
+      content:
+        description: Some sample.
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+    sample_y:
+      content: {}
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_c
+  Experiment:
+    experiment_i:
+      content: {}
+      relations:
+        samples:
+          targetClass: Sample
+          targetResources:
+            - sample_x
+            - sample_y

--- a/tests/fixtures/example_transformations/rename_id_property/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/rename_id_property/single/transformed.schemapack.yaml
@@ -1,0 +1,47 @@
+# a more advanced schemapack:
+schemapack: 0.3.0
+classes:
+  File:
+    id:
+      propertyName: ghga_accession
+      description: File identifier assigned by GHGA.
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true

--- a/tests/fixtures/example_workflows/rename_id_property_multiple/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_multiple/transformed.datapack.yaml
@@ -1,0 +1,58 @@
+datapack: 0.3.0
+resources:
+  File:
+    file_a:
+      content:
+        filename: file_a.fastq
+        format: FASTQ
+        checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
+        size: 12321
+    file_b:
+      content:
+        filename: file_b.fastq
+        format: FASTQ
+        checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
+        size: 12314
+    file_c:
+      content:
+        filename: file_c.fastq
+        format: FASTQ
+        checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
+        size: 12123
+  Dataset:
+    dataset_1:
+      content:
+        dac_contact: dac@example.org
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+            - file_c
+  Sample:
+    sample_x:
+      content:
+        description: Some sample.
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+    sample_y:
+      content: {}
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_c
+  Experiment:
+    experiment_i:
+      content: {}
+      relations:
+        samples:
+          targetClass: Sample
+          targetResources:
+            - sample_x
+            - sample_y

--- a/tests/fixtures/example_workflows/rename_id_property_multiple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_multiple/transformed.schemapack.yaml
@@ -1,0 +1,50 @@
+# a more advanced schemapack:
+schemapack: 0.3.0
+classes:
+  File:
+    id:
+      propertyName: accession
+      description: Id property name is now accession.
+    content: ../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: accession
+      description: Id property name is now accession.
+    content: ../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: accession
+      description: Id property name is now accession.
+    content: ../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: accession
+      description: Id property name is now accession.
+    content: ../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true

--- a/tests/fixtures/example_workflows/rename_id_property_multiple/workflow.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_multiple/workflow.yaml
@@ -1,7 +1,7 @@
 operations:
   # Rename id property with accession
   - name: rename_id_property
-    description: "Rename id property for each {{ class_name }}"
+    description: "Rename id property for {{ class_name }}"
     args:
       class_name: "{{{ item.class_name }}}"
       id_property_name: "{{{ item.id_property_name }}}"

--- a/tests/fixtures/example_workflows/rename_id_property_multiple/workflow.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_multiple/workflow.yaml
@@ -1,0 +1,17 @@
+operations:
+  # Rename id property with accession
+  - name: rename_id_property
+    description: "Rename id property for each {{ class_name }}"
+    args:
+      class_name: "{{{ item.class_name }}}"
+      id_property_name: "{{{ item.id_property_name }}}"
+      description: Id property name is now accession.
+    loop:
+      - class_name: File
+        id_property_name: accession
+      - class_name: Dataset
+        id_property_name: accession
+      - class_name: Sample
+        id_property_name: accession
+      - class_name: Experiment
+        id_property_name: accession

--- a/tests/fixtures/transformations.py
+++ b/tests/fixtures/transformations.py
@@ -33,6 +33,9 @@ from metldata.builtin_transformations.infer_relation.main import (
 from metldata.builtin_transformations.merge_relations.main import (
     MERGE_RELATIONS_TRANSFORMATION,
 )
+from metldata.builtin_transformations.rename_id_property.main import (
+    RENAME_ID_PROPERTY_TRANSFORMATION,
+)
 from metldata.builtin_transformations.transform_content.main import (
     TRANSFORM_CONTENT_TRANSFORMATION,
 )
@@ -50,6 +53,7 @@ TRANSFORMATIONS_BY_NAME: dict[str, TransformationDefinition] = {
     "infer_relation": INFER_RELATION_TRANSFORMATION,
     "merge_relations": MERGE_RELATIONS_TRANSFORMATION,
     "transform_content": TRANSFORM_CONTENT_TRANSFORMATION,
+    "rename_id_property": RENAME_ID_PROPERTY_TRANSFORMATION,
 }
 
 

--- a/tests/fixtures/workflow.py
+++ b/tests/fixtures/workflow.py
@@ -35,6 +35,9 @@ from metldata.builtin_transformations.infer_relation.main import (
 from metldata.builtin_transformations.merge_relations.main import (
     MERGE_RELATIONS_TRANSFORMATION,
 )
+from metldata.builtin_transformations.rename_id_property.main import (
+    RENAME_ID_PROPERTY_TRANSFORMATION,
+)
 from metldata.builtin_transformations.transform_content.main import (
     TRANSFORM_CONTENT_TRANSFORMATION,
 )
@@ -55,6 +58,7 @@ WORKFLOW_BY_NAME: list[str] = [
     "infer_multiple",
     "duplicate_multiple_delete_one_embed_relation",
     "duplicate_infer_delete_merge",
+    "rename_id_property_multiple",
 ]
 TRANSFORMATION_REGISTRY = {
     "delete_class": DELETE_CLASS_TRANSFORMATION,
@@ -62,6 +66,7 @@ TRANSFORMATION_REGISTRY = {
     "infer_relation": INFER_RELATION_TRANSFORMATION,
     "merge_relations": MERGE_RELATIONS_TRANSFORMATION,
     "transform_content": TRANSFORM_CONTENT_TRANSFORMATION,
+    "rename_id_property": RENAME_ID_PROPERTY_TRANSFORMATION,
 }
 
 


### PR DESCRIPTION
This PR adds a transformation to rename the id property in the schemapack model. It does not introduce any change to the datapack, since the datapack specification does not include the id property name. 