### PR TITLE
add class transformation

### DIFF
--- a/src/metldata/builtin_transformations/__init__.py
+++ b/src/metldata/builtin_transformations/__init__.py
@@ -16,6 +16,9 @@
 
 """Built-in transformations"""
 
+from metldata.builtin_transformations.add_class import (
+    ADD_CLASS_TRANSFORMATION,  # noqa: F401
+)
 from metldata.builtin_transformations.delete_class import (
     DELETE_CLASS_TRANSFORMATION,  # noqa: F401
 )

--- a/src/metldata/builtin_transformations/add_class/__init__.py
+++ b/src/metldata/builtin_transformations/add_class/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A transformation to add classes."""
+
+# shortcuts:
+from metldata.builtin_transformations.add_class.main import (
+    ADD_CLASS_TRANSFORMATION,
+)
+
+__all__ = ["ADD_CLASS_TRANSFORMATION"]

--- a/src/metldata/builtin_transformations/add_class/assumptions.py
+++ b/src/metldata/builtin_transformations/add_class/assumptions.py
@@ -19,7 +19,6 @@ from schemapack.spec.schemapack import SchemaPack
 
 from metldata.builtin_transformations.add_class.config import (
     AddClassConfig,
-    RelationSpec,
 )
 from metldata.builtin_transformations.common.assumptions.path_assumptions import (
     check_class_does_not_exist,
@@ -30,16 +29,13 @@ from metldata.transform.exceptions import ModelAssumptionError
 
 def check_model_assumptions(model: SchemaPack, config: AddClassConfig) -> None:
     """Check model assumptions for the add class transformation."""
+    # Check that the new class does not already exist in the model
     check_class_does_not_exist(model=model, class_name=config.class_name)
     check_globally_unique_ids(model=model)
 
+    # Check that the target classes of relations exist in the model."""
     for relation in config.relations:
-        check_relation_target_exists(model=model, relation=relation)
-
-
-def check_relation_target_exists(model: SchemaPack, relation: RelationSpec) -> None:
-    """Check that the target class of a relation exists in the model."""
-    check_class_exists(model=model, class_name=relation.targetClass)
+        check_class_exists(model=model, class_name=relation.targetClass)
 
 
 def check_globally_unique_ids(model: SchemaPack) -> None:

--- a/src/metldata/builtin_transformations/add_class/assumptions.py
+++ b/src/metldata/builtin_transformations/add_class/assumptions.py
@@ -1,0 +1,55 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assumptions for the 'add class' transformation."""
+
+from schemapack.spec.schemapack import SchemaPack
+
+from metldata.builtin_transformations.add_class.config import (
+    AddClassConfig,
+    RelationSpec,
+)
+from metldata.builtin_transformations.common.assumptions.path_assumptions import (
+    check_class_does_not_exist,
+    check_class_exists,
+)
+from metldata.transform.exceptions import ModelAssumptionError
+
+
+def check_model_assumptions(model: SchemaPack, config: AddClassConfig) -> None:
+    """Check model assumptions for the add class transformation."""
+    check_class_does_not_exist(model=model, class_name=config.class_name)
+    check_globally_unique_ids(model=model)
+
+    for relation in config.relations:
+        check_relation_target_exists(model=model, relation=relation)
+
+
+def check_relation_target_exists(model: SchemaPack, relation: RelationSpec) -> None:
+    """Check that the target class of a relation exists in the model."""
+    check_class_exists(model=model, class_name=relation.targetClass)
+
+
+def check_globally_unique_ids(model: SchemaPack) -> None:
+    """Check that the input model does not contain duplicate resource ids across classes.
+    Not conforming to globally unique id would cause ambiguities when mapping the
+    relations of the new class to the existing resources.
+    """
+    if not model.globallyUniqueIds:
+        raise ModelAssumptionError(
+            "The input model must have globally unique ids across all classes to use"
+            "the 'add class' transformation. Please ensure that the 'globallyUniqueIds'"
+            "flag is set to True in the model."
+        )

--- a/src/metldata/builtin_transformations/add_class/config.py
+++ b/src/metldata/builtin_transformations/add_class/config.py
@@ -27,7 +27,7 @@ class RelationSpec(ClassRelation):
 
     relation_property_name: str = Field(description="The name of the relation.")
     target_resources: str = Field(
-        description="Field in the new class's annotation holding the FK to the target resource."
+        description="Field in the new class's annotation holding the foreign key to the target resource."
     )
 
 

--- a/src/metldata/builtin_transformations/add_class/config.py
+++ b/src/metldata/builtin_transformations/add_class/config.py
@@ -1,0 +1,56 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Models for configuration used in the 'add class' transformation."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+from schemapack.spec.schemapack import ClassRelation
+
+
+class RelationSpec(ClassRelation):
+    """A model extending a schemapack relation specification with additional annotation property
+    pointing the field holding the references resource id.
+    """
+
+    relation_property_name: str = Field(description="The name of the relation.")
+    target_resources: str = Field(
+        description="Field in the new class's annotation holding the FK to the target resource."
+    )
+
+
+class AddClassConfig(BaseSettings):
+    """A model describing a configuration for adding a class."""
+
+    class_name: str = Field(
+        default=...,
+        description="The name of the class to add.",
+    )
+    id_property_name: str = Field(
+        default=...,
+        description="The property used as the resource ID.",
+    )
+    content_schema: dict = Field(
+        default=...,
+        description="A valid JSON Schema object describing the class content.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Description of the class.",
+    )
+    relations: list[RelationSpec] = Field(
+        default_factory=list,
+        description="Relations from the new class to existing classes.",
+    )

--- a/src/metldata/builtin_transformations/add_class/data_transform.py
+++ b/src/metldata/builtin_transformations/add_class/data_transform.py
@@ -50,6 +50,10 @@ def add_data_class(
     if class_name in modified_data["resources"]:
         raise EvitableTransformationError()
 
+    _validate_relation_targets_exist(
+        data=data, annotation_resources=annotation_resources, relations=relations
+    )
+
     modified_data["resources"][class_name] = {
         resource_id: {
             "content": _get_resource_content(
@@ -63,6 +67,69 @@ def add_data_class(
     }
 
     return DataPack.model_validate(modified_data)
+
+
+def _validate_relation_targets_exist(
+    *, data: DataPack, annotation_resources: dict, relations: list[RelationSpec]
+) -> None:
+    """Validate that all resource IDs referenced by relations exist in the data.
+
+    Since a single annotation field may reference resources belonging to several
+    target classes, referenced IDs are validated per field against the union of
+    resources of all that field's target classes, rather than per relation.
+    """
+    grouped_relations = _group_relations_by_target_resources(relations)
+    for target_resources_field, target_classes in grouped_relations.items():
+        referenced_ids = _referenced_ids(
+            annotation_resources=annotation_resources,
+            target_resources_field=target_resources_field,
+        )
+        existing_ids: set[str] = set()
+        for target_class in target_classes:
+            existing_ids.update(data.resources[target_class].keys())
+
+        missing_ids = referenced_ids - existing_ids
+        if missing_ids:
+            raise InvalidAnnotationError(
+                f"Annotation references non-existing resources for "
+                f"'{target_resources_field}': {missing_ids}"
+            )
+
+
+def _group_relations_by_target_resources(
+    relations: list[RelationSpec],
+) -> dict[str, list[str]]:
+    """Group relation specs by the annotation field holding their target IDs.
+
+    A single annotation field may hold IDs referring to resources of several
+    different target classes, so each field is mapped to the list of all
+    classes that field's relations may target.
+    """
+    grouped_relations: dict[str, list[str]] = {}
+    for relation in relations:
+        grouped_relations.setdefault(relation.target_resources, []).append(
+            relation.targetClass
+        )
+    return grouped_relations
+
+
+def _as_id_list(ids: list[str] | str | None) -> list[str]:
+    """Normalize a relation field value to a list of IDs."""
+    if ids is None:
+        return []
+    if isinstance(ids, str):
+        return [ids]
+    return ids
+
+
+def _referenced_ids(
+    *, annotation_resources: dict, target_resources_field: str
+) -> set[str]:
+    """Collect all IDs referenced via the given field across all annotated resources."""
+    referenced_ids: set[str] = set()
+    for resource in annotation_resources.values():
+        referenced_ids.update(_as_id_list(resource.get(target_resources_field)))
+    return referenced_ids
 
 
 def _get_resource_content(*, resource: dict, content_schema: dict) -> dict:
@@ -114,9 +181,7 @@ def _matched_target_ids(
     An annotation field whose IDs span several classes is partitioned by keeping, per
     relation spec, only the IDs present in that spec's ``targetClass``.
     """
-    referenced_ids = resource.get(relation.target_resources) or []
-    if isinstance(referenced_ids, str):
-        referenced_ids = [referenced_ids]
+    referenced_ids = _as_id_list(resource.get(relation.target_resources))
     target_class_resources = data.resources[relation.targetClass].keys()
     return [id_ for id_ in referenced_ids if id_ in target_class_resources]
 

--- a/src/metldata/builtin_transformations/add_class/data_transform.py
+++ b/src/metldata/builtin_transformations/add_class/data_transform.py
@@ -41,7 +41,7 @@ def add_data_class(
 
     try:
         annotation_resources = annotation.model_dump()["resources"][class_name]
-    except (KeyError, TypeError) as exc:
+    except KeyError as exc:
         raise InvalidAnnotationError(
             "The annotation is missing the required 'resources' field. "
             "Expected structure: {'resources': {<class_name>: {<resource_id>: {'content': {...}, 'relations': {...}}, ...}, ...}}"

--- a/src/metldata/builtin_transformations/add_class/data_transform.py
+++ b/src/metldata/builtin_transformations/add_class/data_transform.py
@@ -1,0 +1,135 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data transformation logic for the 'add class' transformation."""
+
+import jsonschema
+from pydantic import BaseModel
+from schemapack.spec.datapack import DataPack
+
+from metldata.builtin_transformations.add_class.config import RelationSpec
+from metldata.builtin_transformations.common.utils import data_to_dict
+from metldata.transform.exceptions import (
+    DataTransformationError,
+    EvitableTransformationError,
+    InvalidAnnotationError,
+)
+
+
+def add_data_class(
+    *,
+    data: DataPack,
+    annotation: BaseModel,
+    class_name: str,
+    content_schema: dict,
+    relations: list[RelationSpec],
+) -> DataPack:
+    """Add a new class entry to the provided data."""
+    modified_data = data_to_dict(data)
+
+    try:
+        annotation_resources = annotation.model_dump()["resources"][class_name]
+    except (KeyError, TypeError) as exc:
+        raise InvalidAnnotationError(
+            "The annotation is missing the required 'resources' field. "
+            "Expected structure: {'resources': {<class_name>: {<resource_id>: {'content': {...}, 'relations': {...}}, ...}, ...}}"
+        ) from exc
+
+    if class_name in modified_data["resources"]:
+        raise EvitableTransformationError()
+
+    modified_data["resources"][class_name] = {
+        resource_id: {
+            "content": _get_resource_content(
+                resource=resource, content_schema=content_schema
+            ),
+            "relations": _get_resource_relations(
+                data=data, resource=resource, relations=relations
+            ),
+        }
+        for resource_id, resource in annotation_resources.items()
+    }
+
+    return DataPack.model_validate(modified_data)
+
+
+def _get_resource_content(*, resource: dict, content_schema: dict) -> dict:
+    """Extract the content of a resource according to the content schema."""
+    content_properties = set(content_schema.get("properties", {}).keys())
+    content = {
+        key: value for key, value in resource.items() if key in content_properties
+    }
+    try:
+        jsonschema.validate(content, content_schema)
+    except jsonschema.ValidationError as exc:
+        raise DataTransformationError(
+            f"Resource content does not match the content schema: {exc.message}"
+        ) from exc
+
+    return content
+
+
+def _get_resource_relations(
+    *, data: DataPack, resource: dict, relations: list[RelationSpec]
+) -> dict:
+    """Map each relation spec to the resource's resolved relation entry."""
+    return {
+        relation.relation_property_name: _resolve_relation(
+            data=data, resource=resource, relation=relation
+        )
+        for relation in relations
+    }
+
+
+def _resolve_relation(
+    *, data: DataPack, resource: dict, relation: RelationSpec
+) -> dict:
+    """Resolve a single relation entry for one annotated resource."""
+    matched_ids = _matched_target_ids(data=data, resource=resource, relation=relation)
+    return {
+        "targetClass": relation.targetClass,
+        "targetResources": _apply_target_cardinality(
+            matched_ids=matched_ids, relation=relation
+        ),
+    }
+
+
+def _matched_target_ids(
+    *, data: DataPack, resource: dict, relation: RelationSpec
+) -> list[str]:
+    """Return the referenced IDs that exist in the relation's ``targetClass``.
+
+    An annotation field whose IDs span several classes is partitioned by keeping, per
+    relation spec, only the IDs present in that spec's ``targetClass``.
+    """
+    referenced_ids = resource.get(relation.target_resources) or []
+    if isinstance(referenced_ids, str):
+        referenced_ids = [referenced_ids]
+    target_class_resources = data.resources[relation.targetClass].keys()
+    return [id_ for id_ in referenced_ids if id_ in target_class_resources]
+
+
+def _apply_target_cardinality(
+    *, matched_ids: list[str], relation: RelationSpec
+) -> list[str] | str | None:
+    """Shape matched target IDs to the relation's target cardinality."""
+    if relation.multiple.target:
+        return matched_ids
+    if len(matched_ids) > 1:
+        raise DataTransformationError(
+            f"Expected at most one target resource for relation "
+            f"'{relation.relation_property_name}', but found multiple: {matched_ids}"
+        )
+    return matched_ids[0] if matched_ids else None

--- a/src/metldata/builtin_transformations/add_class/data_transform.py
+++ b/src/metldata/builtin_transformations/add_class/data_transform.py
@@ -113,15 +113,6 @@ def _group_relations_by_target_resources(
     return grouped_relations
 
 
-def _as_id_list(ids: list[str] | str | None) -> list[str]:
-    """Normalize a relation field value to a list of IDs."""
-    if ids is None:
-        return []
-    if isinstance(ids, str):
-        return [ids]
-    return ids
-
-
 def _referenced_ids(
     *, annotation_resources: dict, target_resources_field: str
 ) -> set[str]:
@@ -130,6 +121,15 @@ def _referenced_ids(
     for resource in annotation_resources.values():
         referenced_ids.update(_as_id_list(resource.get(target_resources_field)))
     return referenced_ids
+
+
+def _as_id_list(ids: list[str] | str | None) -> list[str]:
+    """Normalize a relation field value to a list of IDs."""
+    if ids is None:
+        return []
+    if isinstance(ids, str):
+        return [ids]
+    return ids
 
 
 def _get_resource_content(*, resource: dict, content_schema: dict) -> dict:

--- a/src/metldata/builtin_transformations/add_class/main.py
+++ b/src/metldata/builtin_transformations/add_class/main.py
@@ -1,0 +1,101 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A transformation to add classes."""
+
+from schemapack.spec.datapack import DataPack
+from schemapack.spec.schemapack import SchemaPack
+
+from metldata.builtin_transformations.add_class.assumptions import (
+    check_model_assumptions,
+)
+from metldata.builtin_transformations.add_class.config import (
+    AddClassConfig,
+)
+from metldata.builtin_transformations.add_class.data_transform import (
+    add_data_class,
+)
+from metldata.builtin_transformations.add_class.model_transform import (
+    add_model_class,
+)
+from metldata.builtin_transformations.registry import register_transformation
+from metldata.transform.base import (
+    DataTransformer,
+    SubmissionAnnotation,
+    TransformationDefinition,
+)
+
+
+class AddClassTransformer(DataTransformer[AddClassConfig, SubmissionAnnotation]):
+    """A transformer that adds a class to data."""
+
+    def transform(self, data: DataPack, annotation: SubmissionAnnotation) -> DataPack:
+        """Transforms data.
+
+        Args:
+            data: The data as DataPack to be transformed.
+
+        Raises:
+            DataTransformationError:
+                if the transformation fails.
+        """
+        return add_data_class(
+            data=data,
+            annotation=annotation,
+            class_name=self._config.class_name,
+            content_schema=self._config.content_schema,
+            relations=self._config.relations,
+        )
+
+
+def check_model_assumptions_wrapper(model: SchemaPack, config: AddClassConfig) -> None:
+    """Check the assumptions of the model.
+
+    Raises:
+        ModelAssumptionError:
+            if the model does not fulfill the assumptions.
+    """
+    check_model_assumptions(model=model, config=config)
+
+
+def transform_model(model: SchemaPack, config: AddClassConfig) -> SchemaPack:
+    """Transform the data model.
+
+    Raises:
+        DataModelTransformationError:
+            if the transformation fails.
+    """
+    return add_model_class(
+        model=model,
+        class_name=config.class_name,
+        id_property_name=config.id_property_name,
+        content_schema=config.content_schema,
+        description=config.description,
+        relations=config.relations,
+    )
+
+
+ADD_CLASS_TRANSFORMATION = TransformationDefinition[AddClassConfig](
+    config_cls=AddClassConfig,
+    check_model_assumptions=check_model_assumptions_wrapper,
+    transform_model=transform_model,
+    data_transformer_factory=AddClassTransformer,
+)
+
+
+@register_transformation("add_class")
+def add_class_transformation() -> TransformationDefinition[AddClassConfig]:
+    """Get the transformation definition for the add_class transformation."""
+    return ADD_CLASS_TRANSFORMATION

--- a/src/metldata/builtin_transformations/add_class/model_transform.py
+++ b/src/metldata/builtin_transformations/add_class/model_transform.py
@@ -1,0 +1,65 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model transformation logic for the 'add class' transformation."""
+
+from schemapack.spec.schemapack import (
+    ClassDefinition,
+    ClassRelation,
+    IDSpec,
+    SchemaPack,
+)
+
+from metldata.builtin_transformations.add_class.config import RelationSpec
+from metldata.builtin_transformations.common.utils import model_to_dict
+
+
+def add_model_class(  # noqa: PLR0913
+    *,
+    model: SchemaPack,
+    class_name: str,
+    id_property_name: str,
+    content_schema: dict,
+    description: str | None,
+    relations: list[RelationSpec],
+) -> SchemaPack:
+    """Add a new class to the model."""
+    new_class = ClassDefinition.model_validate(
+        {
+            "description": description,
+            "id": IDSpec(propertyName=id_property_name),
+            "content": content_schema,
+            "relations": _build_relations(relations),
+        }
+    )
+
+    model_dict = model_to_dict(model)
+    model_dict["classes"][class_name] = new_class
+    return SchemaPack.model_validate(model_dict)
+
+
+def _build_relations(relations: list[RelationSpec]) -> dict[str, ClassRelation]:
+    """Convert config relation specs into a dict of ClassRelation objects."""
+    return {
+        relation.relation_property_name: ClassRelation.model_validate(
+            {
+                "description": relation.description,
+                "targetClass": relation.targetClass,
+                "mandatory": relation.mandatory,
+                "multiple": relation.multiple,
+            }
+        )
+        for relation in relations
+    }

--- a/src/metldata/builtin_transformations/replace_resource_ids/data_transform.py
+++ b/src/metldata/builtin_transformations/replace_resource_ids/data_transform.py
@@ -25,7 +25,10 @@ from metldata.builtin_transformations.common.custom_types import (
     ResourceId,
 )
 from metldata.builtin_transformations.common.utils import data_to_dict
-from metldata.transform.exceptions import EvitableTransformationError
+from metldata.transform.exceptions import (
+    EvitableTransformationError,
+    InvalidAnnotationError,
+)
 
 
 def replace_data_resource_ids(
@@ -66,15 +69,18 @@ def _get_resource_accessions(*, class_name: str, annotation: BaseModel) -> Acces
     """Extract resource ids from annotations."""
     try:
         accession_map = annotation.model_dump()["accession_map"]
-    except KeyError as exc:
-        raise ValueError(
+    except (KeyError, TypeError) as exc:
+        raise InvalidAnnotationError(
             "The annotation is missing the required 'accession_map' field. "
             "Expected structure: {'accession_map': {<class_name>: {<old_id>: <new_id>, ...}, ...}}"
         ) from exc
 
     resource_accessions = accession_map.get(class_name)
     if resource_accessions is None:
-        raise ValueError(f"No accession map found for class '{class_name}'.")
+        raise InvalidAnnotationError(
+            f"No accession map found for class '{class_name}'. "
+            "Expected structure: {'accession_map': {<class_name>: {<old_id>: <new_id>, ...}, ...}}"
+        )
 
     return resource_accessions
 

--- a/src/metldata/builtin_transformations/replace_resource_ids/data_transform.py
+++ b/src/metldata/builtin_transformations/replace_resource_ids/data_transform.py
@@ -69,7 +69,7 @@ def _get_resource_accessions(*, class_name: str, annotation: BaseModel) -> Acces
     """Extract resource ids from annotations."""
     try:
         accession_map = annotation.model_dump()["accession_map"]
-    except (KeyError, TypeError) as exc:
+    except KeyError as exc:
         raise InvalidAnnotationError(
             "The annotation is missing the required 'accession_map' field. "
             "Expected structure: {'accession_map': {<class_name>: {<old_id>: <new_id>, ...}, ...}}"

--- a/src/metldata/transform/exceptions.py
+++ b/src/metldata/transform/exceptions.py
@@ -40,6 +40,10 @@ class ModelTransformationError(RuntimeError):
     """
 
 
+class InvalidAnnotationError(RuntimeError):
+    """Raised when the annotation provided to a transformation is missing required fields."""
+
+
 class DataTransformationError(RuntimeError):
     """Raised when a transformation failed when applied to data in datapack-format.
     This exception should only be raised when the error could not have been caught

--- a/tests/fixtures/annotation.py
+++ b/tests/fixtures/annotation.py
@@ -25,16 +25,10 @@ OldAccession: TypeAlias = str
 NewAccession: TypeAlias = str
 
 
-class EmptySubmissionAnnotation(BaseModel):
-    """An empty submission annotation model for testing purposes."""
-
-
-EMPTY_SUBMISSION_ANNOTATION = EmptySubmissionAnnotation()
-
-
-class AccessionAnnotation(BaseModel):
-    """A submission annotation model with an accession field.
-    Example: {`accession_map`:{`File`:{`file_a`: `TESTS0000000001`}}}
+class Annotation(BaseModel):
+    """Combined submission annotation carrying data for any built-in transformation.
+    Each transformation reads only the field it needs.
     """
 
-    accession_map: dict[ClassName, dict[OldAccession, NewAccession]]
+    accession_map: dict[ClassName, dict[OldAccession, NewAccession]] | None = None
+    resources: dict[ClassName, dict[str, dict]] | None = None

--- a/tests/fixtures/example_data/advanced.datapack.yaml
+++ b/tests/fixtures/example_data/advanced.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_data/invalid_minimal.datapack.yaml
+++ b/tests/fixtures/example_data/invalid_minimal.datapack.yaml
@@ -1,5 +1,5 @@
 # Misses content property defined in the content schema:
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     example_file_a:

--- a/tests/fixtures/example_data/minimal.datapack.yaml
+++ b/tests/fixtures/example_data/minimal.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     example_file_a:

--- a/tests/fixtures/example_data/valid_minimal.datapack.yaml
+++ b/tests/fixtures/example_data/valid_minimal.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     example_file_a:

--- a/tests/fixtures/example_models/advanced.schemapack.yaml
+++ b/tests/fixtures/example_models/advanced.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_models/minimal.schemapack.yaml
+++ b/tests/fixtures/example_models/minimal.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/add_class/multiple_target_classes/annotation.yaml
+++ b/tests/fixtures/example_transformations/add_class/multiple_target_classes/annotation.yaml
@@ -1,0 +1,13 @@
+resources:
+  Provenance:
+    prov_1:
+      note: Derived from one sample and two files.
+      derived_from:
+        - sample_x
+        - file_a
+        - file_b
+    prov_2:
+      note: Derived from one sample and one file.
+      derived_from:
+        - sample_y
+        - file_c

--- a/tests/fixtures/example_transformations/add_class/multiple_target_classes/config.yaml
+++ b/tests/fixtures/example_transformations/add_class/multiple_target_classes/config.yaml
@@ -1,0 +1,29 @@
+class_name: Provenance
+id_property_name: alias
+content_schema:
+  type: object
+  additionalProperties: false
+  properties:
+    note:
+      type: string
+  required:
+    - note
+relations:
+  - relation_property_name: derived_from_samples
+    targetClass: Sample
+    mandatory:
+      origin: false
+      target: false
+    multiple:
+      origin: false
+      target: true
+    target_resources: derived_from
+  - relation_property_name: derived_from_files
+    targetClass: File
+    mandatory:
+      origin: false
+      target: false
+    multiple:
+      origin: false
+      target: true
+    target_resources: derived_from

--- a/tests/fixtures/example_transformations/add_class/multiple_target_classes/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/multiple_target_classes/input.schemapack.yaml
@@ -1,0 +1,46 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+classes:
+  File:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true

--- a/tests/fixtures/example_transformations/add_class/multiple_target_classes/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/multiple_target_classes/transformed.datapack.yaml
@@ -1,0 +1,84 @@
+datapack: 4.2.0
+resources:
+  File:
+    file_a:
+      content:
+        filename: file_a.fastq
+        format: FASTQ
+        checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
+        size: 12321
+    file_b:
+      content:
+        filename: file_b.fastq
+        format: FASTQ
+        checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
+        size: 12314
+    file_c:
+      content:
+        filename: file_c.fastq
+        format: FASTQ
+        checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
+        size: 12123
+  Dataset:
+    dataset_1:
+      content:
+        dac_contact: dac@example.org
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+            - file_c
+  Sample:
+    sample_x:
+      content:
+        description: Some sample.
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+    sample_y:
+      content: {}
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_c
+  Experiment:
+    experiment_i:
+      content: {}
+      relations:
+        samples:
+          targetClass: Sample
+          targetResources:
+            - sample_x
+            - sample_y
+  Provenance:
+    prov_1:
+      content:
+        note: Derived from one sample and two files.
+      relations:
+        derived_from_samples:
+          targetClass: Sample
+          targetResources:
+            - sample_x
+        derived_from_files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+    prov_2:
+      content:
+        note: Derived from one sample and one file.
+      relations:
+        derived_from_samples:
+          targetClass: Sample
+          targetResources:
+            - sample_y
+        derived_from_files:
+          targetClass: File
+          targetResources:
+            - file_c

--- a/tests/fixtures/example_transformations/add_class/multiple_target_classes/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/multiple_target_classes/transformed.schemapack.yaml
@@ -1,0 +1,74 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+classes:
+  File:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true
+  Provenance:
+    id:
+      propertyName: alias
+    content:
+      type: object
+      additionalProperties: false
+      properties:
+        note:
+          type: string
+      required:
+        - note
+    relations:
+      derived_from_samples:
+        targetClass: Sample
+        mandatory:
+          origin: false
+          target: false
+        multiple:
+          origin: false
+          target: true
+      derived_from_files:
+        targetClass: File
+        mandatory:
+          origin: false
+          target: false
+        multiple:
+          origin: false
+          target: true

--- a/tests/fixtures/example_transformations/add_class/no_relations/annotation.yaml
+++ b/tests/fixtures/example_transformations/add_class/no_relations/annotation.yaml
@@ -1,0 +1,6 @@
+resources:
+  Biospecimen:
+    biosample_1:
+      tissue: blood
+    biosample_2:
+      tissue: adipose

--- a/tests/fixtures/example_transformations/add_class/no_relations/config.yaml
+++ b/tests/fixtures/example_transformations/add_class/no_relations/config.yaml
@@ -1,0 +1,10 @@
+class_name: Biospecimen
+id_property_name: alias
+content_schema:
+  type: object
+  additionalProperties: false
+  properties:
+    tissue:
+      type: string
+  required:
+    - tissue

--- a/tests/fixtures/example_transformations/add_class/no_relations/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/no_relations/input.schemapack.yaml
@@ -1,0 +1,46 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+classes:
+  File:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true

--- a/tests/fixtures/example_transformations/add_class/no_relations/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/no_relations/transformed.datapack.yaml
@@ -1,0 +1,65 @@
+datapack: 4.2.0
+resources:
+  File:
+    file_a:
+      content:
+        filename: file_a.fastq
+        format: FASTQ
+        checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
+        size: 12321
+    file_b:
+      content:
+        filename: file_b.fastq
+        format: FASTQ
+        checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
+        size: 12314
+    file_c:
+      content:
+        filename: file_c.fastq
+        format: FASTQ
+        checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
+        size: 12123
+  Dataset:
+    dataset_1:
+      content:
+        dac_contact: dac@example.org
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+            - file_c
+  Sample:
+    sample_x:
+      content:
+        description: Some sample.
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+    sample_y:
+      content: {}
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_c
+  Experiment:
+    experiment_i:
+      content: {}
+      relations:
+        samples:
+          targetClass: Sample
+          targetResources:
+            - sample_x
+            - sample_y
+  Biospecimen:
+    biosample_1:
+      content:
+        tissue: blood
+    biosample_2:
+      content:
+        tissue: adipose

--- a/tests/fixtures/example_transformations/add_class/no_relations/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/no_relations/transformed.schemapack.yaml
@@ -1,0 +1,57 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+classes:
+  File:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true
+  Biospecimen:
+    id:
+      propertyName: alias
+    content:
+      type: object
+      additionalProperties: false
+      properties:
+        tissue:
+          type: string
+      required:
+        - tissue

--- a/tests/fixtures/example_transformations/add_class/with_relation/annotation.yaml
+++ b/tests/fixtures/example_transformations/add_class/with_relation/annotation.yaml
@@ -1,0 +1,8 @@
+resources:
+  Biospecimen:
+    biosample_1:
+      tissue: blood
+      sample_id: sample_x
+    biosample_2:
+      tissue: adipose
+      sample_id: sample_y

--- a/tests/fixtures/example_transformations/add_class/with_relation/config.yaml
+++ b/tests/fixtures/example_transformations/add_class/with_relation/config.yaml
@@ -1,0 +1,20 @@
+class_name: Biospecimen
+id_property_name: alias
+content_schema:
+  type: object
+  additionalProperties: false
+  properties:
+    tissue:
+      type: string
+  required:
+    - tissue
+relations:
+  - relation_property_name: sample
+    targetClass: Sample
+    mandatory:
+      origin: false
+      target: true
+    multiple:
+      origin: false
+      target: false
+    target_resources: sample_id

--- a/tests/fixtures/example_transformations/add_class/with_relation/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/with_relation/input.schemapack.yaml
@@ -1,0 +1,46 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+classes:
+  File:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true

--- a/tests/fixtures/example_transformations/add_class/with_relation/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/with_relation/transformed.datapack.yaml
@@ -1,0 +1,73 @@
+datapack: 4.2.0
+resources:
+  File:
+    file_a:
+      content:
+        filename: file_a.fastq
+        format: FASTQ
+        checksum: 1a5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92b8
+        size: 12321
+    file_b:
+      content:
+        filename: file_b.fastq
+        format: FASTQ
+        checksum: 2b5ac10ab42911dc0224172c118a326d9a4c03969112a2f3eb1ad971e96e92c9
+        size: 12314
+    file_c:
+      content:
+        filename: file_c.fastq
+        format: FASTQ
+        checksum: a9c24870071da03f78515e6197048f3a2172e90e597e9250cd01a0cb8f0986ed
+        size: 12123
+  Dataset:
+    dataset_1:
+      content:
+        dac_contact: dac@example.org
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+            - file_c
+  Sample:
+    sample_x:
+      content:
+        description: Some sample.
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_a
+            - file_b
+    sample_y:
+      content: {}
+      relations:
+        files:
+          targetClass: File
+          targetResources:
+            - file_c
+  Experiment:
+    experiment_i:
+      content: {}
+      relations:
+        samples:
+          targetClass: Sample
+          targetResources:
+            - sample_x
+            - sample_y
+  Biospecimen:
+    biosample_1:
+      content:
+        tissue: blood
+      relations:
+        sample:
+          targetClass: Sample
+          targetResources: sample_x
+    biosample_2:
+      content:
+        tissue: adipose
+      relations:
+        sample:
+          targetClass: Sample
+          targetResources: sample_y

--- a/tests/fixtures/example_transformations/add_class/with_relation/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/add_class/with_relation/transformed.schemapack.yaml
@@ -1,0 +1,66 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+classes:
+  File:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/File.schema.json
+  Dataset:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Dataset.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: true
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Sample:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Sample.schema.json
+    relations:
+      files:
+        targetClass: File
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: false
+          target: true
+  Experiment:
+    id:
+      propertyName: alias
+    content: ../../../example_content_schemas/Experiment.schema.json
+    relations:
+      samples:
+        targetClass: Sample
+        multiple:
+          origin: false
+          target: true
+        mandatory:
+          origin: true
+          target: true
+  Biospecimen:
+    id:
+      propertyName: alias
+    content:
+      type: object
+      additionalProperties: false
+      properties:
+        tissue:
+          type: string
+      required:
+        - tissue
+    relations:
+      sample:
+        targetClass: Sample
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: false
+          target: false

--- a/tests/fixtures/example_transformations/delete_class/single/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/delete_class/single/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/delete_class/single/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/delete_class/single/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/delete_class/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/delete_class/single/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/delete_class/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/delete_class/single/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/duplicate_class/single/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/duplicate_class/single/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/duplicate_class/single/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/duplicate_class/single/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/duplicate_class/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/duplicate_class/single/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/duplicate_class/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/duplicate_class/single/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/infer_relation/active_relation/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/active_relation/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/infer_relation/active_relation/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/active_relation/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/infer_relation/complex_relation/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/complex_relation/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/infer_relation/complex_relation/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/complex_relation/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/infer_relation/passive_relation_multiple_target/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/passive_relation_multiple_target/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/infer_relation/passive_relation_multiple_target/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/passive_relation_multiple_target/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/infer_relation/passive_relation_multiple_target/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/passive_relation_multiple_target/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/infer_relation/passive_relation_single_target/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/passive_relation_single_target/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/infer_relation/passive_relation_single_target/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/passive_relation_single_target/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/infer_relation/passive_relation_single_target/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/infer_relation/passive_relation_single_target/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/merge_relations/single/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/merge_relations/single/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   ResearchDataFile:
     file_a:

--- a/tests/fixtures/example_transformations/merge_relations/single/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/merge_relations/single/input.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   ProcessedDataFile:
     id:

--- a/tests/fixtures/example_transformations/merge_relations/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/merge_relations/single/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   ResearchDataFile:
     file_a:

--- a/tests/fixtures/example_transformations/merge_relations/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/merge_relations/single/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   ProcessedDataFile:
     id:

--- a/tests/fixtures/example_transformations/rename_id_property/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/rename_id_property/single/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/rename_id_property/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/rename_id_property/single/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/replace_resource_ids/single/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/replace_resource_ids/single/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     TESTS0000000001:

--- a/tests/fixtures/example_transformations/replace_resource_ids/single/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/replace_resource_ids/single/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/set_id_uniqueness_scope/globally_unique/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/set_id_uniqueness_scope/globally_unique/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/set_id_uniqueness_scope/globally_unique/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/set_id_uniqueness_scope/globally_unique/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/set_id_uniqueness_scope/locally_unique/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/set_id_uniqueness_scope/locally_unique/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/set_id_uniqueness_scope/locally_unique/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/set_id_uniqueness_scope/locally_unique/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/transform_content/add_content_property/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/add_content_property/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/transform_content/add_content_property/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/add_content_property/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/transform_content/add_content_property/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/add_content_property/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/transform_content/add_content_property/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/add_content_property/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_content_values_of_type_list/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/count_references/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_references/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/transform_content/count_references/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_references/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/transform_content/count_references/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_references/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_transformations/transform_content/count_references/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/count_references/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/input.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/input.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/transformed.datapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/transformed.schemapack.yaml
+++ b/tests/fixtures/example_transformations/transform_content/sum_operation_stringified_config/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_workflows/add_multiple_content_properties/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/add_multiple_content_properties/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/add_multiple_content_properties/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/add_multiple_content_properties/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/count_references/input.datapack.yaml
+++ b/tests/fixtures/example_workflows/count_references/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/count_references/input.schemapack.yaml
+++ b/tests/fixtures/example_workflows/count_references/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/count_references/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/count_references/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/count_references/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/count_references/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/delete_multiple/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/delete_multiple/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/delete_multiple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/delete_multiple/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/duplicate_infer_delete_merge/input.datapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_infer_delete_merge/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   ResearchDataFile:
     file_a:

--- a/tests/fixtures/example_workflows/duplicate_infer_delete_merge/input.schemapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_infer_delete_merge/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   ResearchDataFile:
     id:

--- a/tests/fixtures/example_workflows/duplicate_infer_delete_merge/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_infer_delete_merge/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   DatasetSummary:
     dataset_1:

--- a/tests/fixtures/example_workflows/duplicate_infer_delete_merge/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_infer_delete_merge/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   DatasetSummary:
     id:

--- a/tests/fixtures/example_workflows/duplicate_multiple_delete_one/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_multiple_delete_one/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/duplicate_multiple_delete_one/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_multiple_delete_one/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/duplicate_multiple_delete_one_embed_relation/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_multiple_delete_one_embed_relation/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/duplicate_multiple_delete_one_embed_relation/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_multiple_delete_one_embed_relation/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/duplicate_one_delete_multiple/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_one_delete_multiple/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/duplicate_one_delete_multiple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/duplicate_one_delete_multiple/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow/input.datapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Analysis:
     ANALYSIS_1:

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow/input.schemapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow/input.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 description: Metadata schema for the German Human Genome-Phenome Archive (GHGA)
 classes:
   Analysis:

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   DatasetStats:
     GHGAD74245202504286:

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 description: Metadata schema for the German Human Genome-Phenome Archive (GHGA)
 classes:
   DatasetStats:

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/annotation.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/annotation.yaml
@@ -1,0 +1,149 @@
+resources:
+  Study:
+    STUDY_A:
+      id: STUDY_A
+      title: The A Study
+      description: A study that is the A study
+      types:
+        - SYNTHETIC_GENOMICS
+        - WHOLE_GENOME_SEQUENCING
+      ega_accession: EGASTUDY12345
+      affiliations:
+        - Some Institute
+        - Some other Institute
+  Dataset:
+    DS_A:
+      id: DS_A
+      title: The complete-A dataset
+      description: An interesting dataset A of complete example set
+      types:
+        - A Type
+        - Another Type
+      ega_accession: EGADATASET12345
+      study_id: STUDY_A
+      dap_id: DAP_1
+      files:
+        - INDV_SF_1
+        - EXP_METHOD_SF_1
+        - RESEARCH_DATA_FILE_1
+        - RESEARCH_DATA_FILE_2
+        - RESEARCH_DATA_FILE_3
+        - PROCESSED_DATA_FILE_1
+        - PROCESSED_DATA_FILE_2
+    DS_B:
+      id: DS_B
+      title: The complete-B dataset
+      description: An interesting dataset B of complete example set
+      types:
+        - And another Type
+      ega_accession: EGADATASET12346
+      study_id: STUDY_A
+      dap_id: DAP_2
+      files:
+        - ANALYSIS_METHOD_SF_1
+        - RESEARCH_DATA_FILE_4
+        - RESEARCH_DATA_FILE_5
+        - RESEARCH_DATA_FILE_6
+        - RESEARCH_DATA_FILE_7
+        - RESEARCH_DATA_FILE_8
+        - RESEARCH_DATA_FILE_9
+  DataAccessPolicy:
+    DAP_1:
+      id: DAP_1
+      name: DAP 1
+      description: A Data Access Policy 1
+      text: This is a very permissible DAP
+      url: http://some/policy
+      duo_permission_id: DUO:0000007
+      duo_modifier_ids:
+        - DUO:0000043
+      ega_accession: EGADAP12345
+      dac_id: DAC_1
+    DAP_2:
+      id: DAP_2
+      name: DAP 2
+      description: A Data Access Policy 2
+      text: This is a very strict DAP
+      url: http://some/other/policy
+      duo_permission_id: DUO:0000004
+      duo_modifier_ids:
+        - DUO:0000026
+      ega_accession: EGADAP12346
+      dac_id: DAC_1
+  DataAccessCommittee:
+    DAC_1:
+      id: DAC_1
+      name: DAC 1
+      email: dac_institute_a@dac.dac
+      institute: institute_a
+      ega_accession: EGADAC12345
+  Publication:
+    PUB_1:
+      id: PUB_1
+      title: A paper of a study
+      abstract: This study aims finding findings.
+      authors:
+        - John Doe
+      year: 1965
+      journal: Journal of Studies
+      doi: 10.1234/abcd.5678
+      study_id: STUDY_A
+    PUB_2:
+      id: PUB_2
+      title: Another paper of the same study
+      abstract: This study aims finding more findings.
+      authors:
+        - John Doe
+      year: 1967
+      journal: Journal of Studies
+      doi: 10.9876/efgh.5432
+      study_id: STUDY_A
+accession_map:
+  DataAccessPolicy:
+    DAP_1: GHGAP39078595522073
+    DAP_2: GHGAP74385913061043
+  Experiment:
+    EXP_1: GHGAX13173356020149
+    EXP_2: GHGAX20628128281395
+  Study:
+    STUDY_A: GHGAS90595893121388
+    STUDY_B: GHGAS83708013118412
+  Sample:
+    SAMPLE_1: GHGAN40916564477704
+    SAMPLE_2: GHGAN95009105506931
+  ExperimentMethodSupportingFile:
+    EXP_METHOD_SF_1: GHGAF50031360829229
+  AnalysisMethodSupportingFile:
+    ANALYSIS_METHOD_SF_1: GHGAF63452619346923
+  AnalysisMethod:
+    ANALYSIS_METHOD_1: GHGAZ05327499072648
+  ExperimentMethod:
+    EXP_METHOD_1: GHGAQ73903495407713
+  Analysis:
+    ANALYSIS_1: GHGAR06714308553089
+    ANALYSIS_2: GHGAR22047943578622
+  ProcessDataFile:
+    PROCESSED_DATA_FILE_1: GHGAF60886013814437
+    PROCESSED_DATA_FILE_2: GHGAF72800304806670
+  Individual:
+    INDV_1: GHGAI82390199469794
+  ResearchDataFile:
+    RESEARCH_DATA_FILE_1: GHGAF92340426512426
+    RESEARCH_DATA_FILE_2: GHGAF83486778440393
+    RESEARCH_DATA_FILE_3: GHGAF92457618468357
+    RESEARCH_DATA_FILE_4: GHGAF49843811495133
+    RESEARCH_DATA_FILE_5: GHGAF61513295806667
+    RESEARCH_DATA_FILE_6: GHGAF27516027389054
+    RESEARCH_DATA_FILE_7: GHGAF16843085345544
+    RESEARCH_DATA_FILE_8: GHGAF07439123661122
+    RESEARCH_DATA_FILE_9: GHGAF45325417160362
+  Dataset:
+    DS_A: GHGAD74245202504286
+    DS_B: GHGAD84882883098593
+  DataAccessCommittee:
+    DAC_1: GHGAC10160329657595
+  Publication:
+    PUB_1: GHGAU48555233772598
+    PUB_2: GHGAU62255628048570
+  IndividualSupportingFile:
+    INDV_SF_1: GHGAF34257230533249

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/input.datapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/input.datapack.yaml
@@ -1,0 +1,340 @@
+datapack: 4.2.0
+resources:
+  Analysis:
+    ANALYSIS_1:
+      content:
+        title: Analysis 1
+        description: Analysis 1 is done like this.
+        type: Sequence Variation
+        ega_accession: EGAANALYSIS12345
+      relations:
+        analysis_method:
+          targetClass: AnalysisMethod
+          targetResources: ANALYSIS_METHOD_1
+        research_data_files:
+          targetClass: ResearchDataFile
+          targetResources:
+            - RESEARCH_DATA_FILE_1
+            - RESEARCH_DATA_FILE_2
+    ANALYSIS_2:
+      content:
+        title: Analysis 2
+        description: Analysis 2 is done like this.
+        type: Sequence Variation
+        ega_accession: EGAANALYSIS12346
+      relations:
+        analysis_method:
+          targetClass: AnalysisMethod
+          targetResources: ANALYSIS_METHOD_1
+        research_data_files:
+          targetClass: ResearchDataFile
+          targetResources:
+            - RESEARCH_DATA_FILE_3
+  AnalysisMethod:
+    ANALYSIS_METHOD_1:
+      content:
+        name: Analysis 1
+        description: Analysis 1 is done like this.
+        type: Sequence Variation
+        workflow_name: workflow 1
+        workflow_version: 1.0.0
+        workflow_repository: https://github.com/WF1/tree/1.0.0
+        workflow_doi: 10.1234/fake.doi.2024.56789
+        workflow_tasks: Variant Calling
+        parameters:
+          - key: output-format
+            value: VCF
+          - key: threads
+            value: "8"
+        software_versions:
+          - key: GATK
+            value: 4.5.0
+  AnalysisMethodSupportingFile:
+    ANALYSIS_METHOD_SF_1:
+      content:
+        format: TXT
+        name: analysis_method_1_parameters.txt
+        ega_accession: EGAANALYSISMETHOD123456
+        included_in_submission: true
+      relations:
+        analysis_method:
+          targetClass: AnalysisMethod
+          targetResources: ANALYSIS_METHOD_1
+  Individual:
+    INDV_1:
+      content:
+        phenotypic_features_terms:
+          - Leukemia
+        phenotypic_features_ids:
+          - HP:0001909
+        diagnosis_ids:
+          - ICD-10:C92
+        diagnosis_terms:
+          - Myeloid leukaemia
+        sex: MALE
+        geographical_region_term: Italy
+        geographical_region_id: NCIT:C16761
+        ancestry_terms:
+          - European
+        ancestry_ids:
+          - HANCESTRO:0005
+  IndividualSupportingFile:
+    INDV_SF_1:
+      content:
+        format: JSON
+        name: indv_1_phenopackage.json
+        included_in_submission: true
+      relations:
+        individual:
+          targetClass: Individual
+          targetResources: INDV_1
+  Sample:
+    SAMPLE_1:
+      content:
+        name: GHGAS_blood_sample1
+        type: CF_DNA
+        biological_replicate: 1
+        description: Arterial blood sample 1
+        storage: FREEZER
+        disease_or_healthy: DISEASE
+        case_control_status: CASE
+        ega_accession: EGASAMPLE12345
+        biospecimen_name: Biospecmen material
+        biospecimen_type: Blood
+        biospecimen_description: Blood biospecimen
+        biospecimen_age_at_sampling: 66_TO_70
+        biospecimen_vital_status_at_sampling: ALIVE
+        biospecimen_tissue_term: blood
+        biospecimen_tissue_id: BTO:0000089
+        biospecimen_isolation: BLOOD_DRAW
+        biospecimen_storage: REFRIGERATOR
+      relations:
+        individual:
+          targetClass: Individual
+          targetResources: INDV_1
+    SAMPLE_2:
+      content:
+        name: GHGAS_tissue_sample1
+        type: CF_DNA
+        biological_replicate: 1
+        description: white adipose tissue sample 1
+        storage: ULTRA_LOW_FREEZER
+        disease_or_healthy: HEALTHY
+        case_control_status: CONTROL
+        ega_accession: EGASAMPLE12346
+        biospecimen_name: Another biospecimen material
+        biospecimen_type: Subcutaneous fat
+        biospecimen_description: Subcutaneous fat biospecimen
+        biospecimen_age_at_sampling: 66_TO_70
+        biospecimen_vital_status_at_sampling: ALIVE
+        biospecimen_tissue_term: subcutaneous adipose tissue
+        biospecimen_tissue_id: BTO:0004042
+        biospecimen_isolation: SURGICAL_REMOVAL
+        biospecimen_storage: REFRIGERATOR
+      relations:
+        individual:
+          targetClass: Individual
+          targetResources: INDV_1
+  ExperimentMethod:
+    EXP_METHOD_1:
+      content:
+        name: Experiment Method 1
+        description: Experiment method 1 is conducted like this.
+        type: DNA-seq
+        library_type: WGS
+        library_selection_methods:
+          - UNSPECIFIED
+        library_preparation: PCR-amplification
+        library_preparation_kit_retail_name: 10X_GENOMICS_CHROMIUM_SINGLE_CELL_3_V2
+        library_preparation_kit_manufacturer: Illumina
+        primer: GENE_SPECIFIC
+        end_bias: FULL_LENGTH
+        target_regions:
+          - chr6:123456-12345678
+        instrument_model: 454_GS
+        sequencing_center: Center A
+        sequencing_read_length: long
+        sequencing_layout: SE
+        target_coverage: x50
+        flow_cell_id: ID_Cell 1_Lane_1
+        flow_cell_type: ILLUMINA_NOVA_SEQ_S4
+        sample_barcode_read: INDEX1
+        ega_accession: EGAEXPERIMENTMETHOD12345
+  ExperimentMethodSupportingFile:
+    EXP_METHOD_SF_1:
+      content:
+        format: TXT
+        name: exp_method_1_protocol.txt
+        ega_accession: EGAEXPERIMENTMETHOD123456
+        included_in_submission: true
+      relations:
+        experiment_method:
+          targetClass: ExperimentMethod
+          targetResources: EXP_METHOD_1
+  Experiment:
+    EXP_1:
+      content:
+        title: Experiment 1
+        description: Experiment 1 is done like this.
+        type: DNA-seq
+        ega_accession: EGAEXP12345
+      relations:
+        sample:
+          targetClass: Sample
+          targetResources: SAMPLE_1
+        experiment_method:
+          targetClass: ExperimentMethod
+          targetResources: EXP_METHOD_1
+    EXP_2:
+      content:
+        title: Experiment 2
+        description: Experiment 2 is done like this.
+        type: DNA-seq
+        ega_accession: EGAEXP12346
+      relations:
+        sample:
+          targetClass: Sample
+          targetResources: SAMPLE_2
+        experiment_method:
+          targetClass: ExperimentMethod
+          targetResources: EXP_METHOD_1
+  ResearchDataFile:
+    RESEARCH_DATA_FILE_1:
+      content:
+        format: FASTQ
+        technical_replicate: 1
+        sequencing_lane_id: LANE_123
+        name: SAMPLE_1_SPECIMEN_1_FILE_1.fastq.gz
+        ega_accession: EGAFILE12346
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_1
+            - EXP_2
+    RESEARCH_DATA_FILE_2:
+      content:
+        format: FASTQ
+        technical_replicate: 2
+        sequencing_lane_id: LANE_124
+        name: SAMPLE_1_SPECIMEN_1_FILE_2.fastq.gz
+        ega_accession: EGAFILE12347
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_1
+    RESEARCH_DATA_FILE_3:
+      content:
+        format: FASTQ
+        technical_replicate: 3
+        sequencing_lane_id: LANE_125
+        name: SAMPLE_1_SPECIMEN_1_FILE_3.fastq.gz
+        ega_accession: EGAFILE12348
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_1
+    RESEARCH_DATA_FILE_4:
+      content:
+        format: FASTQ
+        technical_replicate: 1
+        sequencing_lane_id: LANE_126
+        name: SAMPLE_2_SPECIMEN_1_FILE_4.fastq.gz
+        ega_accession: EGAFILE12349
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_2
+    RESEARCH_DATA_FILE_5:
+      content:
+        format: FASTQ
+        technical_replicate: 2
+        sequencing_lane_id: LANE_127
+        name: SAMPLE_2_SPECIMEN_1_FILE_5.fastq.gz
+        ega_accession: EGAFILE12350
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_2
+    RESEARCH_DATA_FILE_6:
+      content:
+        format: FASTQ
+        technical_replicate: 3
+        sequencing_lane_id: LANE_128
+        name: SAMPLE_2_SPECIMEN_1_FILE_6.fastq.gz
+        ega_accession: EGAFILE12351
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_2
+    RESEARCH_DATA_FILE_7:
+      content:
+        format: FASTQ
+        technical_replicate: 4
+        sequencing_lane_id: LANE_129
+        name: SAMPLE_2_SPECIMEN_1_FILE_7.fastq.gz
+        ega_accession: EGAFILE12352
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_2
+    RESEARCH_DATA_FILE_8:
+      content:
+        format: FASTQ
+        technical_replicate: 5
+        sequencing_lane_id: LANE_130
+        name: SAMPLE_2_SPECIMEN_1_FILE_8.fastq.gz
+        ega_accession: EGAFILE12353
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_2
+    RESEARCH_DATA_FILE_9:
+      content:
+        format: FASTQ
+        technical_replicate: 6
+        sequencing_lane_id: LANE_131
+        name: SAMPLE_2_SPECIMEN_1_FILE_9.fastq.gz
+        ega_accession: EGAFILE12354
+        included_in_submission: true
+      relations:
+        experiments:
+          targetClass: Experiment
+          targetResources:
+            - EXP_2
+  ProcessDataFile:
+    PROCESSED_DATA_FILE_1:
+      content:
+        format: VCF
+        name: SAMPLE_1_SPECIMEN_FILE_1_2.vcf.gz
+        ega_accession: EGAPROCESSED12345
+        included_in_submission: true
+      relations:
+        analysis:
+          targetClass: Analysis
+          targetResources: ANALYSIS_1
+    PROCESSED_DATA_FILE_2:
+      content:
+        format: VCF
+        name: SAMPLE_1_SPECIMEN_1_FILE_3.vcf.gz
+        ega_accession: EGAPROCESSED12346
+        included_in_submission: true
+      relations:
+        analysis:
+          targetClass: Analysis
+          targetResources: ANALYSIS_2

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/input.schemapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/input.schemapack.yaml
@@ -1,0 +1,1433 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+description: Metadata schema for the German Human Genome-Phenome Archive (GHGA)
+classes:
+  Analysis:
+    description: An Analysis is a data transformation that transforms input data
+      to output data.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Analysis is a data transformation that transforms input
+        data to output data.
+      properties:
+        description:
+          description: A description summarizing how this Analysis was carried
+            out (e.g., description of computational tools, pipelines,
+            workflows).
+          type:
+            - string
+            - "null"
+        ega_accession:
+          description: The EGA accession of the 'Analysis' entity (EGAZ).
+          type:
+            - string
+            - "null"
+        title:
+          description: The title that describes an entity.
+          type: string
+        type:
+          description: The type of this Analysis.
+          type:
+            - string
+            - "null"
+      required:
+        - title
+      title: Analysis
+      type: object
+      $id: src/content_schemas/Analysis
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      analysis_method:
+        targetClass: AnalysisMethod
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+      research_data_files:
+        targetClass: ResearchDataFile
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: true
+  AnalysisMethod:
+    description: An Analysis Method captures the workflow steps that were
+      performed to analyze data obtained from an Experiment.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Analysis Method captures the workflow steps that were
+        performed to analyze data obtained from an Experiment.
+      properties:
+        attributes:
+          description: One or more attributes that further characterize this
+            Analysis Method.
+          items:
+            additionalProperties: false
+            description: A key/value pair that further characterizes an entity.
+            properties:
+              key:
+                description: The key of an attribute.
+                type: string
+              key_type:
+                description: A semantic type that characterizes the attribute
+                  key (e.g., oxygen saturation measurement (MAXO:0000616)).
+                type:
+                  - string
+                  - "null"
+              value:
+                description: The value for an attribute (e.g., a numerical value
+                  without the units).
+                type: string
+              value_type:
+                description: The value_type that characterizes the attribute
+                  value (e.g., percentage (SIO:001413)).
+                type:
+                  - string
+                  - "null"
+            required:
+              - key
+              - value
+            title: Attribute
+            type: object
+            $id: src/content_schemas/Attribute
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type:
+            - array
+            - "null"
+        description:
+          description: Description of an entity.
+          type: string
+        name:
+          description: A name identifying this Analysis Method.
+          type: string
+        parameters:
+          description: Key/value pairs where key corresponds to a parameter name
+            and value corresponds to a parameter value (e.g., 'aligner' =
+            'star_salmon',  'hisat2_build_memory' = '200.GB', 'split_fastq' =
+            50000000).
+          items:
+            additionalProperties: false
+            description: A key/value pair that further characterizes an entity.
+            properties:
+              key:
+                description: The key of an attribute.
+                type: string
+              key_type:
+                description: A semantic type that characterizes the attribute
+                  key (e.g., oxygen saturation measurement (MAXO:0000616)).
+                type:
+                  - string
+                  - "null"
+              value:
+                description: The value for an attribute (e.g., a numerical value
+                  without the units).
+                type: string
+              value_type:
+                description: The value_type that characterizes the attribute
+                  value (e.g., percentage (SIO:001413)).
+                type:
+                  - string
+                  - "null"
+            required:
+              - key
+              - value
+            title: Attribute
+            type: object
+            $id: src/content_schemas/Attribute
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type:
+            - array
+            - "null"
+        software_versions:
+          description: key/value pairs where key corresponds to a software name
+            and value corresponds to a version descriptor (e.g., `salmon` =
+            '1.3.0', `trim-galore` = '0.6.6', `bedtools` = '2.29.2').
+          items:
+            additionalProperties: false
+            description: A key/value pair that further characterizes an entity.
+            properties:
+              key:
+                description: The key of an attribute.
+                type: string
+              key_type:
+                description: A semantic type that characterizes the attribute
+                  key (e.g., oxygen saturation measurement (MAXO:0000616)).
+                type:
+                  - string
+                  - "null"
+              value:
+                description: The value for an attribute (e.g., a numerical value
+                  without the units).
+                type: string
+              value_type:
+                description: The value_type that characterizes the attribute
+                  value (e.g., percentage (SIO:001413)).
+                type:
+                  - string
+                  - "null"
+            required:
+              - key
+              - value
+            title: Attribute
+            type: object
+            $id: src/content_schemas/Attribute
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type:
+            - array
+            - "null"
+        type:
+          description: "The type of an entity. Note: Not to be confused with rdf:type."
+          type: string
+        workflow_doi:
+          description: A digital object identifier for the workflow. Can be a
+            publication or the workflow commit that was used for the Analysis.
+          type: string
+        workflow_name:
+          description: The workflow name.
+          type: string
+        workflow_repository:
+          description: The workflow repository (e.g., the URL).
+          type: string
+        workflow_tasks:
+          description: Tasks performed by the workflow
+          type:
+            - string
+            - "null"
+        workflow_version:
+          description: The workflow version.
+          type:
+            - string
+            - "null"
+      required:
+        - name
+        - description
+        - type
+        - workflow_name
+        - workflow_repository
+        - workflow_doi
+      title: AnalysisMethod
+      type: object
+      $id: src/content_schemas/AnalysisMethod
+      $schema: https://json-schema.org/draft/2019-09/schema
+  AnalysisMethodSupportingFile:
+    description: An Analysis Method Supporting File is a File that contains
+      additional information relevant for the Analysis Method, such as
+      (unstructured) protocols or task descriptions.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Analysis Method Supporting File is a File that contains
+        additional information relevant for the Analysis Method, such as
+        (unstructured) protocols or task descriptions.
+      properties:
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+            - string
+            - "null"
+        format:
+          description: Enum to capture Supporting File types.
+          enum:
+            - CSV
+            - JSON
+            - PED
+            - TSV
+            - TXT
+            - YAML
+            - OTHER
+          title: SupportingFileFormatEnum
+          type: string
+          $id: src/content_schemas/enums/SupportingFileFormatEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        included_in_submission:
+          description: Whether a File is included in the Submission or not.
+          type: boolean
+        name:
+          description: The given filename.
+          type: string
+      required:
+        - format
+        - name
+        - included_in_submission
+      title: AnalysisMethodSupportingFile
+      type: object
+      $id: src/content_schemas/AnalysisMethodSupportingFile
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      analysis_method:
+        targetClass: AnalysisMethod
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+  Experiment:
+    description: An Experiment is an investigation that consists of a
+      coordinated set of actions and observations designed to generate data with
+      the goal of verifying, falsifying, or establishing the validity of a
+      hypothesis.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Experiment is an investigation that consists of a
+        coordinated set of actions and observations designed to generate data
+        with the goal of verifying, falsifying, or establishing the validity of
+        a hypothesis.
+      properties:
+        attributes:
+          description: Key/value pairs corresponding to an entity.
+          items:
+            additionalProperties: false
+            description: A key/value pair that further characterizes an entity.
+            properties:
+              key:
+                description: The key of an attribute.
+                type: string
+              key_type:
+                description: A semantic type that characterizes the attribute
+                  key (e.g., oxygen saturation measurement (MAXO:0000616)).
+                type:
+                  - string
+                  - "null"
+              value:
+                description: The value for an attribute (e.g., a numerical value
+                  without the units).
+                type: string
+              value_type:
+                description: The value_type that characterizes the attribute
+                  value (e.g., percentage (SIO:001413)).
+                type:
+                  - string
+                  - "null"
+            required:
+              - key
+              - value
+            title: Attribute
+            type: object
+            $id: src/content_schemas/Attribute
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type:
+            - array
+            - "null"
+        description:
+          description: A detailed description of this Experiment.
+          type:
+            - string
+            - "null"
+        ega_accession:
+          description: The EGA accession of the 'Run' entity (EGAR).
+          type:
+            - string
+            - "null"
+        title:
+          description: The title for this Experiment (e.g., GHGAE_PBMC_RNAseq).
+          type: string
+        type:
+          description: The type of this Experiment.
+          type:
+            - string
+            - "null"
+      required:
+        - title
+      title: Experiment
+      type: object
+      $id: src/content_schemas/Experiment
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      experiment_method:
+        targetClass: ExperimentMethod
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+      sample:
+        targetClass: Sample
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+  ExperimentMethod:
+    description: The Experiment Method captures technical metadata describing
+      the parameters used to generate output from the Sample.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: The Experiment Method captures technical metadata describing
+        the parameters used to generate output from the Sample.
+      properties:
+        attributes:
+          description: One or more attributes that further characterize this
+            Experiment Method.
+          items:
+            additionalProperties: false
+            description: A key/value pair that further characterizes an entity.
+            properties:
+              key:
+                description: The key of an attribute.
+                type: string
+              key_type:
+                description: A semantic type that characterizes the attribute
+                  key (e.g., oxygen saturation measurement (MAXO:0000616)).
+                type:
+                  - string
+                  - "null"
+              value:
+                description: The value for an attribute (e.g., a numerical value
+                  without the units).
+                type: string
+              value_type:
+                description: The value_type that characterizes the attribute
+                  value (e.g., percentage (SIO:001413)).
+                type:
+                  - string
+                  - "null"
+            required:
+              - key
+              - value
+            title: Attribute
+            type: object
+            $id: src/content_schemas/Attribute
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type:
+            - array
+            - "null"
+        description:
+          description: A short description of this Experiment Method.
+          type: string
+        ega_accession:
+          description: The EGA accession of the 'Experiment' entity (EGAX).
+          type:
+            - string
+            - "null"
+        end_bias:
+          description: Permitted values for end bias.
+          enum:
+            - 3_PRIME_END
+            - 5_PRIME_END
+            - FULL_LENGTH
+          title: EndBiasEnum
+          type: string
+          $id: src/content_schemas/enums/EndBiasEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        flow_cell_id:
+          description: Flow cell ID (e.g., Experiment ID_Cell 1_Lane_1).
+          type:
+            - string
+            - "null"
+        flow_cell_type:
+          description: Permitted values for flow cell type.
+          enum:
+            - ELEMENT_BIOSCIENCES_AVITI_LOW_OUTPUT
+            - ELEMENT_BIOSCIENCES_AVITI_MID_OUTPUT
+            - ELEMENT_BIOSCIENCES_AVITI_HIGH_OUTPUT
+            - ILLUMINA_NOVA_SEQ_SP
+            - ILLUMINA_NOVA_SEQ_S1
+            - ILLUMINA_NOVA_SEQ_S2
+            - ILLUMINA_NOVA_SEQ_S4
+            - ILLUMINA_NOVA_SEQ_XPLUS_1_5B
+            - ILLUMINA_NOVA_SEQ_XPLUS_10B
+            - ILLUMINA_NOVA_SEQ_XPLUS_25B
+            - ILLUMINA_MISEQ_MICRO
+            - ILLUMINA_MISEQ_NANO
+            - ILLUMINA_NEXTSEQ_HIGH_OUTPUT
+            - ILLUMINA_NEXTSEQ_MID_OUTPUT
+            - PACBIO_SEQUELL_II
+            - PROMETHION
+            - FLONGLE
+            - MINION
+            - GRIDION
+            - OTHER
+          title: FlowCellTypeEnum
+          type: string
+          $id: src/content_schemas/enums/FlowCellTypeEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        instrument_model:
+          description: Permitted values for the instrument model.
+          enum:
+            - 454_GS
+            - 454_GS_20
+            - 454_GS_FLX
+            - 454_GS_FLX_TITANIUM
+            - 454_GS_FLX+
+            - 454_GS_JUNIOR
+            - AB_310_GENETIC_ANALYZER
+            - AB_3130_GENETIC_ANALYZER
+            - AB_3130XL_GENETIC_ANALYZER
+            - AB_3500_GENETIC_ANALYZER
+            - AB_3500XL_GENETIC_ANALYZER
+            - AB_3730_GENETIC_ANALYZER
+            - AB_3730XL_GENETIC_ANALYZER
+            - AB_5500_GENETIC_ANALYZER
+            - AB_5500XL_GENETIC_ANALYZER
+            - AB_5500XL-W_GENETIC_ANALYSIS_SYSTEM
+            - BGISEQ-50
+            - BGISEQ-500
+            - DNBSEQ-G400
+            - DNBSEQ-G400_FAST
+            - DNBSEQ-G50
+            - DNBSEQ-T7
+            - ELEMENT_AVITI
+            - GRIDION
+            - HELICOS_HELISCOPE
+            - HISEQ_X_FIVE
+            - HISEQ_X_TEN
+            - ILLUMINA_GENOME_ANALYZER
+            - ILLUMINA_GENOME_ANALYZER_II
+            - ILLUMINA_GENOME_ANALYZER_IIX
+            - ILLUMINA_HISCANSQ
+            - ILLUMINA_HISEQ_1000
+            - ILLUMINA_HISEQ_1500
+            - ILLUMINA_HISEQ_2000
+            - ILLUMINA_HISEQ_2500
+            - ILLUMINA_HISEQ_3000
+            - ILLUMINA_HISEQ_4000
+            - ILLUMINA_HISEQ_X
+            - ILLUMINA_MISEQ
+            - ILLUMINA_MINISEQ
+            - ILLUMINA_NOVASEQ_6000
+            - ILLUMINA_NOVASEQ_X
+            - ILLUMINA_ISEQ_100
+            - ILLUMINA_ISCAN
+            - ION_GENESTUDIO_S5
+            - ION_GENESTUDIO_S5_PLUS
+            - ION_GENESTUDIO_S5_PRIME
+            - ION_TORRENT_GENEXUS
+            - ION_TORRENT_PGM
+            - ION_TORRENT_PROTON
+            - ION_TORRENT_S5
+            - ION_TORRENT_S5_XL
+            - MGISEQ-2000RS
+            - MINION
+            - NEXTSEQ_1000
+            - NEXTSEQ_2000
+            - NEXTSEQ_500
+            - NEXTSEQ_550
+            - PACBIO_RS
+            - PACBIO_RS_II
+            - PROMETHION
+            - SEQUEL
+            - SEQUEL_II
+            - SEQUEL_IIE
+            - UG_100
+            - UNSPECIFIED
+            - OTHER
+          title: InstrumentModelEnum
+          type: string
+          $id: src/content_schemas/enums/InstrumentModelEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        library_preparation:
+          description: The general method for preparation of the sequencing
+            library (e.g., KAPA PCR-free).
+          type: string
+        library_preparation_kit_manufacturer:
+          description: The manufacturer of the kit used for library preparation.
+          type:
+            - string
+            - "null"
+        library_preparation_kit_retail_name:
+          description: Permitted values for library preparation kit retail name.
+          enum:
+            - 10X_GENOMICS_CHROMIUM_SINGLE_CELL_3_V2
+            - 10X_GENOMICS_CHROMIUM_SINGLE_CELL_3_V3
+            - 10X_GENOMICS_CHROMIUM_SINGLE_CELL_3_V4
+            - 10X_GENOMICS_CHROMIUM_SINGLE_CELL_5_V3
+            - 10X_GENOMICS_CHROMIUM_ATAC_V2
+            - 10X_GENOMICS_CHROMIUM_MULTIOME_ATAC_RNA
+            - 10X_GENOMICS_CHROMIUM_VISIUM_FF
+            - 10X_GENOMICS_CHROMIUM_VISIUM_FFPE
+            - 10X_GENOMICS_CHROMIUM_VISIUM_CYTASSIST
+            - ACCEL_NGS_2_S_PLUS_DNA_LIBRARY_KIT
+            - ACCEL_NGS_METHYL_SEQ_DNA
+            - AGILENT_STRAND_SPECIFIC_RNA
+            - AGILENT_SURE_SELECT_CUSTOM_ENRICHMENT_KIT
+            - AGILENT_SURE_SELECT_V3
+            - AGILENT_SURE_SELECT_V4
+            - AGILENT_SURE_SELECT_V4_UTRS
+            - AGILENT_SURE_SELECT_V5
+            - AGILENT_SURE_SELECT_V5_UTRS
+            - AGILENT_SURE_SELECT_V6
+            - AGILENT_SURE_SELECT_V6_UTRS
+            - AGILENT_SURE_SELECT_V6_PLUS_ONE
+            - AGILENT_SURE_SELECT_V6_PLUS_TWO
+            - AGILENT_SURE_SELECT_V8
+            - AGILENT_SURE_SELECT_V8_UTRS
+            - AGILENT_SURE_SELECT_V8_NCV
+            - AGILENT_SURE_SELECT_QXT_WGS
+            - AGILENT_SURE_SELECT_XT_HS_HUMAN_ALL_EXON_V7
+            - AGILENT_SURE_SELECT_XT_HS_HUMAN_ALL_EXON_V7_ONE
+            - AGILENT_SURE_SELECT_XT_HS_HUMAN_ALL_EXON_V7_TWO
+            - AGILENT_SURE_SELECT_CLINICAL_RESEARCH_EXOME_V2
+            - AGILENT_SURE_SELECT_CLINICAL_RESEARCH_EXOME_V2_ONE
+            - AGILENT_SURE_SELECT_CLINICAL_RESEARCH_EXOME_V2_TWO
+            - AGILENT_CLEAR_SEQ_COMPREHENSIVE_CANCER_XT
+            - AGILENT_SURE_SELECT_CUSTOM_TIER1
+            - AGILENT_SURE_SELECT_CUSTOM_TIER2
+            - AGILENT_SURE_SELECT_CUSTOM_TIER3
+            - AGILENT_SURE_SELECT_CUSTOM_TIER4
+            - AGILENT_SURE_SELECT_CUSTOM_TIER5
+            - AVENIO_CT_DNA_TARGETED_KIT
+            - AVENIO_CT_DNA_SURVEILLANCE_KIT
+            - AVENIO_CT_DNA_EXPANDED_KIT
+            - IDT_X_GEN_EXOME_RESEARCH_PANEL
+            - ILLUMINA_DNA_PCR_FREE_PREP
+            - ILLUMINA_NEXTERA_DNA_FLEX
+            - ILLUMINA_DNA_PREP
+            - ILLUMINA_NEXTERA_EXOME_ENRICHMENT_KIT
+            - ILLUMINA_DNA_PREP_WITH_ENRICHMENT
+            - ILLUMINA_DNA_PREP_WITH_EXOME_2_5_ENRICHMENT
+            - ILLUMINA_STRANDED_M_RNA_PREP
+            - ILLUMINA_NEXTERA_DNA_LIBRARY_PREPARATION_KIT
+            - ILLUMINA_NEXTERA_XT_DNA_LIBRARY_PREPARATION_KIT
+            - ILLUMINA_RNA_PREP_WITH_ENRICHMENT
+            - ILLUMINA_TRU_SEQ_CH_IP_LIBRARY_PREPARATION_KIT
+            - ILLUMINA_TRU_SEQ_CUSTOM_AMPLICON_LOW_INPUT_KIT
+            - ILLUMINA_TRU_SEQ_CUSTOM_AMPLICON_V_1_5
+            - ILLUMINA_TRU_SEQ_DNA_EXOME
+            - ILLUMINA_TRU_SEQ_DNA_NANO
+            - ILLUMINA_TRU_SEQ_DNA_NANO_LIBRARY_PREP_KIT_FOR_NEO_PREP
+            - ILLUMINA_TRU_SEQ_NANO_DNA_HT
+            - ILLUMINA_TRU_SEQ_NANO_DNA_LT
+            - ILLUMINA_TRU_SEQ_FFPE_DNA_LIBRARY_PREP_QC_KIT
+            - ILLUMINA_TRU_SEQ_DNA_PCR_FREE
+            - ILLUMINA_TRU_SEQ_RNA_LIBRARY_PREP_KIT_V2
+            - ILLUMINA_TRU_SEQ_RNA_EXOME
+            - ILLUMINA_TRU_SEQ_SMALL_RNA_LIBRARY_PREPARATION_KIT
+            - ILLUMINA_TRU_SEQ_STRANDED_TOTAL_RNA
+            - ILLUMINA_TRU_SEQ_STRANDED_M_RNA
+            - ILLUMINA_TRU_SEQ_STRANDED_TOTAL_RNA_WITH_RIBO_ZERO_GOLD
+            - VAHTS_TOTAL_RNA_SEQ_H_M_R_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - ILLUMINA_NEXTERA_XT_DNA
+            - ILLUMINA_TRU_SEQ_TARGETED_RNA_EXPRESSION_STEM_CELL_PANEL
+            - ILLUMINA_TRU_SEQ_TARGETED_RNA_EXPRESSION_P_53_PANEL
+            - ILLUMINA_TRU_SIGHT_ONCOLOGY_500
+            - ILLUMINA_TRU_SIGHT_ONCOLOGY_500_HIGH_THROUGHPUT
+            - ILLUMINA_TRU_SIGHT_ONCOLOGY_500_CT_DNA
+            - ILLUMINA_TRU_SIGHT_RNA_FUSION_PANEL
+            - ILLUMINA_TRU_SIGHT_RNA_PAN_CANCER
+            - ILLUMINA_TRU_SIGHT_TUMOR_15
+            - ILLUMINA_TRU_SIGHT_TUMOR_170
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_BRCA_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_CANCER_HOTSPOT_PANEL_V2
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_CHILDHOOD_CANCER_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_COMPREHENSIVE_PANEL_V3
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_CUSTOM_DNA_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_CUSTOM_RNA_FUSION_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_CUSTOM_RNA_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_FOCUS_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_IMMUNE_REPERTOIRE_PLUS_TCR_BETA_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_IMMUNE_RESPONSE_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_LIBRARY_PREP_INDEXES_AND_ACCESSOIRES
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_MYELOID_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_ON_DEMAND
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_TCR_BETA_SR_PANEL
+            - ILLUMINA_AMPLI_SEQ_FOR_ILLUMINA_TRANSCRIPTOME_HUMAN_GENE_EXPRESSION_PANEL
+            - ILLUMINA_COMPLETE_LONG_READ_PREP_HUMAN
+            - INFORM_ONCO_PANEL_HG19
+            - ION_AMPLI_SEQ_EXOME_KIT
+            - KAPA_HIFI_HOT_START_READYMIX
+            - KAPA_HYPER_PREP_KIT
+            - KAPA_HYPER_PREP_PCR_FREE_KIT
+            - KAPA_HYPER_PLUS_KIT
+            - KAPA_M_RNA_HYPER_PREP_KIT
+            - NEB_NEXT_GLOBIN_R_RNA_DEPLETION_HU_MO_RAT_RNA_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_GLOBIN_R_RNA_DEPLETION_KIT_HUMAN_MOUSE_RAT
+            - NEB_NEXT_GLOBIN_R_RNA_DEPLET_V2_HU_MO_RAT_RNA_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_GLOBIN_R_RNA_DEPLETION_KIT_V2_HUMAN_MOUSE_RAT
+            - NEB_NEXT_RNA_DEPLETION_CORE_REAGENT_SET
+            - NEB_NEXT_RNA_DEPLETION_CORE_REAGENT_SET_RNA_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_POLY_A_M_RNA_MAGNETIC_ISOLATION_MODULE
+            - NEB_NEXT_SINGLE_CELL_LOW_INPUT_CDNA_SYNTHESIS_AND_AMPLIFICATION_MODULE
+            - NEB_NEXT_SINGLE_CELL_LOW_INPUT_RNA_LIBRARY_KIT_FOR_ILLUMINA
+            - NEB_NEXT_RNA_ULTRA_II_FIRST_STRAND_SYNTHESIS_MODULE
+            - NEB_NEXT_RNA_ULTRA_II_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_RNA_ULTRA_II_LIBRARY_PREP_WITH_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_ULTRA_II_DIRECTIONAL_RNA_SAMPLE_WITH_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_ULTRA_II_DIRECTIONAL_RNA_SECOND_STRAND_SYNTHESIS_MODULE
+            - NEB_NEXT_ULTRA_DNA
+            - NEB_NEXT_ULTRA_II_DNA_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_ULTRA_II_DNA_ILLUMINA_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_ULTRA_II_DIRECTIONAL_RNA_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_ULTRA_II_FS_DNA_MODULE
+            - NEB_NEXT_ULTRA_II_END_REPAIR_DA_TAILING_MODULE
+            - NEB_NEXT_ULTRA_II_FS_DNA_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_ULTRA_II_FS_DNA_ILLUMINA_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_ULTRA_II_DNA_PCR_FREE_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_ULTRA_II_FS_DNA_PCR_FREE_SAMPLE_PURIFICATION_BEADS
+            - NEB_NEXT_ULTRA_II_DNA_PCR_FREE_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_ULTRA_II_FS_DNA_PCR_FREE_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_ULTRA_II_LIGATION_MODULE
+            - NEB_NEXT_ULTRA_II_Q5_MASTER_MIX
+            - NEB_NEXT_Q5_HOT_START_HIFI_PCR_MASTER_MIX
+            - NEB_TEMPLATE_SWITCHING_RT_ENZYME_MIX
+            - NEB_NEXT_LIBRARY_PCR_MASTER_MIX
+            - NEB_NEXT_ULTRA_SHEAR
+            - NEB_NEXT_ULTRA_SHEAR_FFPE_DNA_LIBRARY_PREP_KIT
+            - NEB_NEXT_COMPANION_MODULE_ONT_LIGATION_SEQUENCING
+            - NEB_NEXT_FAST_DNA_FRAGMENTATION_AND_LIBRARY_PREP_SET_FOR_ION_TORRENT
+            - NEB_NEXT_FAST_DNA_LIBRARY_PREP_SET_FOR_ION_TORRENT
+            - NEB_NEXT_FFPE_DNA_LIBRARY_PREP_KIT
+            - NEB_NEXT_FFPE_DNA_REPAIR_MIX
+            - NEB_NEXT_FFPE_DNA_REPAIR_V2_MODULE
+            - NEB_NEXT_DS_DNA_FRAGMENTASE
+            - NEB_NEXT_MAGNETIC_SEPARATION_RACK
+            - NEB_NEXT_LIBRARY_QUANT_FOR_ILLUMINA
+            - NEB_NEXT_LIBRARY_QUANT_DNA_STANDARDS
+            - NEB_NEXT_MAGNESIUM_RNA_FRAGMENTATION_MODULE
+            - NEB_NEXT_DIRECT_GENOTYPING_SOLUTION
+            - NEB_NEXT_ENZYMATIC_METHYL_SEQ_CONVERSION_MODULE
+            - NEB_NEXT_ENZYMATIC_METHYL_SEQ_KIT
+            - NEB_NEXT_MULTIPLEX_SMALL_RNA_LIBRARY_PREP_KIT_FOR_ILLUMINA
+            - NEB_NEXT_SMALL_RNA_LIBRARY_PREP_SET_FOR_ILLUMINA_MULTIPLEX_COMPATIBLE
+            - EPI_MARK_5_HMC_AND_5_MC_ANALYSIS_KIT
+            - EPI_MARK_METHYLATED_DNA_ENRICHMENT_KIT
+            - EPI_MARK_N6_METHYLADENOSINE_ENRICHMENT_KIT
+            - EPI_MARK_NUCLEOSOME_ASSEMBLY_KIT
+            - EPI_MARK_HOT_START_TAG_DNA_POLYMERASE
+            - PICO_METHYL_SEQ
+            - TAKARA_SMART_SEQ_V4_ULTRA_LOW_INPUT_RNA_KIT
+            - TAKARA_SMART_ER_STRANDED_TOTAL_RNA_SEQ_KIT
+            - TAKARA_SMART_ER_ULTRA_LOW_INPUT_RNA_KIT
+            - TAKARA_SMART_SEQ2_TAG
+            - TAKARA_SMART_ER_PREP_X_DNA_LIBRARY_KIT
+            - SUPER_SCRIPT_II_RT_BULK
+            - SURE_CELL_ATAC_SEQ_LIBRARY_PREP_KIT
+            - EUROFINS_ENRICHMENT_CUSTOM
+            - TWIST_HUMAN_CORE_EXOME_KIT
+            - TWIST_HUMAN_CORE_EXOME_PLUS_KIT
+            - ULTRALOW_METHYL_SEQ_WITH_TRUE_METHYL_OX_BS
+            - OTHER
+          title: LibraryPreparationKitRetailNameEnum
+          type: string
+          $id: src/content_schemas/enums/LibraryPreparationKitRetailNameEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        library_selection_methods:
+          description: One or more methods used to select for or against,
+            enrich, or screen the material being sequenced (e.g., random, PCA,
+            cDNA).
+          items:
+            description: Permitted vocabulary for library selections.
+            enum:
+              - 5_METHYLCYTIDINE_ANTIBODY_METHOD
+              - CAGE_METHOD
+              - C_DNA_METHOD
+              - CF_H_METHOD
+              - CF_M_METHOD
+              - CF_S_METHOD
+              - CF_T_METHOD
+              - CHIP_SEQ_METHOD
+              - D_NASE_METHOD
+              - HMPR_METHOD
+              - HYBRID_SELECTION_METHOD
+              - MBD2_PROTEIN_METHYL_CP_G_BINDING_DOMAIN_METHOD
+              - MF_METHOD
+              - M_NASE_METHOD
+              - MSLL_METHOD
+              - PCR_METHOD
+              - RACE_METHOD
+              - RANDOM_PCR_METHOD
+              - RANDOM_METHOD
+              - RT_PCR_METHOD
+              - REDUCED_REPRESENTATION_METHOD
+              - RESTRICTION_DIGEST_METHOD
+              - SIZE_FRACTIONATION_METHOD
+              - UNSPECIFIED
+              - OTHER
+            title: LibraryPreparationLibrarySelectionEnum
+            type: string
+            $id: src/content_schemas/enums/LibraryPreparationLibrarySelectionEnum
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type: array
+        library_type:
+          description: The type of the library.
+          enum:
+            - WGS
+            - WXS
+            - WCS
+            - TOTAL_RNA
+            - M_RNA
+            - MI_RNA
+            - NC_RNA
+            - ATAC
+            - METHYLATION
+            - CHROMOSOME_CONFORMATION_CAPTURE
+            - CHIP_SEQ
+            - OTHER
+            - UNSPECIFIED
+          title: LibraryPreparationLibraryTypeEnum
+          type: string
+          $id: src/content_schemas/enums/LibraryPreparationLibraryTypeEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        name:
+          description: A short name identifying this Experiment Method.
+          type: string
+        primer:
+          description: Permitted values for primer.
+          enum:
+            - OLIGO_D_T
+            - RANDOM
+            - GENE_SPECIFIC
+            - OTHER
+          title: PrimerEnum
+          type: string
+          $id: src/content_schemas/enums/PrimerEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        rnaseq_strandedness:
+          description: Permitted values for library preparation RNASeq
+            strandedness.
+          enum:
+            - SENSE
+            - ANTISENSE
+            - UNSTRANDED
+          title: LibraryPreparationRNASeqStrandednessEnum
+          type: string
+          $id: src/content_schemas/enums/LibraryPreparationRNASeqStrandednessEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        sample_barcode_read:
+          description: Permitted values for sample barcode read.
+          enum:
+            - INDEX1
+            - INDEX1_AND_INDEX2
+            - OTHER
+          title: SampleBarcodeReadEnum
+          type: string
+          $id: src/content_schemas/enums/SampleBarcodeReadEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        sequencing_center:
+          description: Center where sample was sequenced.
+          type:
+            - string
+            - "null"
+        sequencing_layout:
+          description: Single-end vs paired-end sequencing.
+          enum:
+            - SE
+            - PE
+            - UNSPECIFIED
+          title: SequencingProtocolSequencingLayoutEnum
+          type: string
+          $id: src/content_schemas/enums/SequencingProtocolSequencingLayoutEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        sequencing_read_length:
+          description: Length of sequencing reads (e.g., long or short or actual
+            number of the read length).
+          type:
+            - string
+            - "null"
+        target_coverage:
+          description: Mean coverage for whole genome sequencing, or mean target
+            coverage for whole exome and targeted sequencing, (i.e. the number
+            of times a particular locus was sequenced).
+          type:
+            - string
+            - "null"
+        target_regions:
+          description: Subset of genes or specific regions of the genome, which
+            are most likely to be involved in the phenotype under study.
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        type:
+          description: The type associated with this Experiment Method.
+          type: string
+      required:
+        - name
+        - description
+        - type
+        - library_type
+        - library_selection_methods
+        - library_preparation
+        - instrument_model
+        - sequencing_layout
+      title: ExperimentMethod
+      type: object
+      $id: src/content_schemas/ExperimentMethod
+      $schema: https://json-schema.org/draft/2019-09/schema
+  ExperimentMethodSupportingFile:
+    description: An Experiment Method Supporting File is a File that contains
+      additional information relevant for the Experiment Method, such as
+      (unstructured) protocols.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Experiment Method Supporting File is a File that contains
+        additional information relevant for the Experiment Method, such as
+        (unstructured) protocols.
+      properties:
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+            - string
+            - "null"
+        format:
+          description: Enum to capture Supporting File types.
+          enum:
+            - CSV
+            - JSON
+            - PED
+            - TSV
+            - TXT
+            - YAML
+            - OTHER
+          title: SupportingFileFormatEnum
+          type: string
+          $id: src/content_schemas/enums/SupportingFileFormatEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        included_in_submission:
+          description: Whether a File is included in the Submission or not.
+          type: boolean
+        name:
+          description: The given filename.
+          type: string
+      required:
+        - format
+        - name
+        - included_in_submission
+      title: ExperimentMethodSupportingFile
+      type: object
+      $id: src/content_schemas/ExperimentMethodSupportingFile
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      experiment_method:
+        targetClass: ExperimentMethod
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+  Individual:
+    description: An Individual is a Person who is participating in a Study.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Individual is a Person who is participating in a Study.
+      properties:
+        ancestry_ids:
+          description: The corresponding ID to the HANCESTRO vocabulary (e.g.,
+            HANCESTRO:0010, HANCESTRO:0005, HANCESTRO:0017).
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        ancestry_terms:
+          description:
+            "A person's descent or lineage from a population. The used
+            terms should be descendants of 'HANCESTRO:0004: ancestry category' (e.g.,
+            African, European, Oceanian)."
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        diagnosis_ids:
+          description: One or more diagnoses that the entity is associated with
+            at the time of retrieval from the organism. The diagnosis is
+            captured using a code from ICD-10 (WHO version). Please restrict the
+            ICD code to the chapter letter and two digits for the main diagnosis
+            (e.g., E10, C01).
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        diagnosis_terms:
+          description: The ICD-10 terms corresponding to the ICD-10 codes (e.g.,
+            Type 1 diabetes mellitus, Malignant neoplasm of base of tongue).
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        geographical_region_id:
+          description: The corresponding ID to the NCIT vocabulary (e.g.,
+            NCIT:C16312, NCIT:C16636, NCIT:C16761).
+          type:
+            - string
+            - "null"
+        geographical_region_term:
+          description:
+            "The Individual's geographical region. The used terms should
+            be descendants of 'NCIT:C25464: country' (e.g., Austria, Germany, Italy)."
+          type:
+            - string
+            - "null"
+        phenotypic_features_ids:
+          description: The corresponding ID to the HPO vocabulary (e.g.,
+            HP:0002732, HP:0012735, HP:0002615).
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        phenotypic_features_terms:
+          description: The phenotypic feature concepts that the entity is
+            associated with at the time of retrieval from the organism. The
+            Phenotypic Feature is captured using a concept from the Human
+            Phenotype Ontology (e.g., Lymph node hypoplasia, Cough,
+            Hypotension).
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        sex:
+          description: The sex of an Individual as as defined in a specific
+            medical and clinical context.
+          enum:
+            - FEMALE
+            - MALE
+            - UNKNOWN
+            - OTHER
+          title: IndividualSexEnum
+          type: string
+          $id: src/content_schemas/enums/IndividualSexEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+      required:
+        - sex
+      title: Individual
+      type: object
+      $id: src/content_schemas/Individual
+      $schema: https://json-schema.org/draft/2019-09/schema
+  IndividualSupportingFile:
+    description: An Individual Supporting File is a File that contains
+      additional information relevant for the Individual, such as ped-files,
+      phenopackets or imaging data.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: An Individual Supporting File is a File that contains
+        additional information relevant for the Individual, such as ped-files,
+        phenopackets or imaging data.
+      properties:
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+            - string
+            - "null"
+        format:
+          description: Enum to capture Supporting File types.
+          enum:
+            - CSV
+            - JSON
+            - PED
+            - TSV
+            - TXT
+            - YAML
+            - OTHER
+          title: SupportingFileFormatEnum
+          type: string
+          $id: src/content_schemas/enums/SupportingFileFormatEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        included_in_submission:
+          description: Whether a File is included in the Submission or not.
+          type: boolean
+        name:
+          description: The given filename.
+          type: string
+      required:
+        - format
+        - name
+        - included_in_submission
+      title: IndividualSupportingFile
+      type: object
+      $id: src/content_schemas/IndividualSupportingFile
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      individual:
+        targetClass: Individual
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+  ProcessDataFile:
+    description: A Process Data File is a File that contains data produced by an
+      Analysis or workflow.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: A Process Data File is a File that contains data produced by
+        an Analysis or workflow.
+      properties:
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+            - string
+            - "null"
+        format:
+          description: Enum to capture Process Data File formats.
+          enum:
+            - BAI
+            - BAM
+            - BCF
+            - BED
+            - CRAM
+            - GFF
+            - HDF5
+            - SAM
+            - VCF
+            - WIG
+            - OTHER
+          title: ProcessDataFileFormatEnum
+          type: string
+          $id: src/content_schemas/enums/ProcessDataFileFormatEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        included_in_submission:
+          description: Whether a File is included in the Submission or not.
+          type: boolean
+        name:
+          description: The given filename.
+          type: string
+      required:
+        - format
+        - name
+        - included_in_submission
+      title: ProcessDataFile
+      type: object
+      $id: src/content_schemas/ProcessDataFile
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      analysis:
+        targetClass: Analysis
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false
+  ResearchDataFile:
+    description: A Research Data File is a File that contains raw data
+      originating from an Experiment.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: A Research Data File is a File that contains raw data
+        originating from an Experiment.
+      properties:
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+            - string
+            - "null"
+        format:
+          description: Enum to capture Research Data File formats.
+          enum:
+            - FASTA
+            - FASTQ
+            - UBAM
+            - FAST5
+            - RAW
+            - D
+            - MZML
+            - MZDATA
+            - IDAT
+            - OTHER
+          title: ResearchDataFileFormatEnum
+          type: string
+          $id: src/content_schemas/enums/ResearchDataFileFormatEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        included_in_submission:
+          description: Whether a File is included in the Submission or not.
+          type: boolean
+        name:
+          description: The given filename.
+          type: string
+        sequencing_lane_id:
+          description: The identifier of a sequencing lane.
+          type:
+            - string
+            - "null"
+        technical_replicate:
+          description: An integer to indicate the technical replicate of this
+            File.
+          type: integer
+      required:
+        - format
+        - technical_replicate
+        - name
+        - included_in_submission
+      title: ResearchDataFile
+      type: object
+      $id: src/content_schemas/ResearchDataFile
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      experiments:
+        targetClass: Experiment
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: true
+  Sample:
+    description: A Sample is a limited quantity of something to be used for
+      testing, analysis, inspection, investigation, demonstration, or trial use.
+      It is prepared from a Biospecimen.
+    id:
+      propertyName: alias
+    content:
+      additionalProperties: false
+      description: A Sample is a limited quantity of something to be used for
+        testing, analysis, inspection, investigation, demonstration, or trial
+        use.  It is prepared from a Biospecimen.
+      properties:
+        attributes:
+          description: Key/value pairs corresponding to an entity.
+          items:
+            additionalProperties: false
+            description: A key/value pair that further characterizes an entity.
+            properties:
+              key:
+                description: The key of an attribute.
+                type: string
+              key_type:
+                description: A semantic type that characterizes the attribute
+                  key (e.g., oxygen saturation measurement (MAXO:0000616)).
+                type:
+                  - string
+                  - "null"
+              value:
+                description: The value for an attribute (e.g., a numerical value
+                  without the units).
+                type: string
+              value_type:
+                description: The value_type that characterizes the attribute
+                  value (e.g., percentage (SIO:001413)).
+                type:
+                  - string
+                  - "null"
+            required:
+              - key
+              - value
+            title: Attribute
+            type: object
+            $id: src/content_schemas/Attribute
+            $schema: https://json-schema.org/draft/2019-09/schema
+          type:
+            - array
+            - "null"
+        biological_replicate:
+          description: An integer to indicate the number of a biological
+            replicate.
+          type:
+            - integer
+            - "null"
+        biospecimen_age_at_sampling:
+          description: Enum to capture the age range that an Indiviudal belongs
+            to.
+          enum:
+            - 0_TO_5
+            - 6_TO_10
+            - 11_TO_15
+            - 16_TO_20
+            - 21_TO_25
+            - 26_TO_30
+            - 31_TO_35
+            - 36_TO_40
+            - 41_TO_45
+            - 46_TO_50
+            - 51_TO_55
+            - 56_TO_60
+            - 61_TO_65
+            - 66_TO_70
+            - 71_TO_75
+            - 76_TO_80
+            - 81_OR_OLDER
+            - UNKNOWN
+          title: AgeRangeEnum
+          type: string
+          $id: src/content_schemas/enums/AgeRangeEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        biospecimen_description:
+          description: A concise description about the Biospecimen source, the
+            collection method, and the protocol which was followed to process
+            this Biospecimen.
+          type:
+            - string
+            - "null"
+        biospecimen_isolation:
+          description: Describes how biomaterial was isolated.
+          enum:
+            - BLOOD_DRAW
+            - SURGICAL_REMOVAL
+            - SALIVA_COLLECTION
+            - BUCCAL_SWAB
+            - OTHER
+            - UNKNOWN
+          title: IsolationEnum
+          type: string
+          $id: src/content_schemas/enums/IsolationEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        biospecimen_name:
+          description: A descriptive name of this Biospecimen (e.g.,
+            GHGAB_caudate_nucleus_biospecimen). This property must not include
+            any personally identifiable data.
+          type:
+            - string
+            - "null"
+        biospecimen_storage:
+          description: Enum to capture how a Sample or Biospecimen was stored.
+          enum:
+            - REFRIGERATOR
+            - FREEZER
+            - ULTRA_LOW_FREEZER
+            - CRYOGENIC_FREEZER
+            - NONE
+            - OTHER
+            - UNKNOWN
+          title: StorageEnum
+          type: string
+          $id: src/content_schemas/enums/StorageEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        biospecimen_tissue_id:
+          description: The corresponding ontology ID for the
+            biospecimen_tissue_term (e.g., BTO:0000671, BTO:0000089,
+            BTO:0000848).
+          type:
+            - string
+            - "null"
+        biospecimen_tissue_term:
+          description: The tissue this Biospecimen originated from. Should be a
+            term from the BRENDA Tissue Ontology vocabulary (e.g., kidney,
+            blood, melanoma cell).
+          type:
+            - string
+            - "null"
+        biospecimen_type:
+          description: The type of Biospecimen.
+          type:
+            - string
+            - "null"
+        biospecimen_vital_status_at_sampling:
+          description: Enum to capture the vital status of an individual.
+          enum:
+            - ALIVE
+            - DECEASED
+            - UNKNOWN
+          title: VitalStatusEnum
+          type: string
+          $id: src/content_schemas/enums/VitalStatusEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        case_control_status:
+          description: Enum to capture whether a condition corresponds to a case
+            or a control condition.
+          enum:
+            - CASE
+            - CONTROL
+            - OTHER
+            - UNKNOWN
+          title: CaseControlStatusEnum
+          type: string
+          $id: src/content_schemas/enums/CaseControlStatusEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        description:
+          description: A concise description about the Sample source, the
+            collection method, and the protocol which was followed to process
+            this Sample.
+          type: string
+        disease_or_healthy:
+          description: Enum to capture whether a condition corresponds to a
+            disease or a healthy state.
+          enum:
+            - DISEASE
+            - HEALTHY
+            - NOT_APPLICABLE
+          title: DiseaseOrHealthyEnum
+          type: string
+          $id: src/content_schemas/enums/DiseaseOrHealthyEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+            - string
+            - "null"
+        name:
+          description: A descriptive name of this Sample (e.g.,
+            GHGAS_Blood_Sample1 or GHGAS_PBMC_RNAseq_S1). This property must not
+            include any personally identifiable data.
+          type: string
+        storage:
+          description: Enum to capture how a Sample or Biospecimen was stored.
+          enum:
+            - REFRIGERATOR
+            - FREEZER
+            - ULTRA_LOW_FREEZER
+            - CRYOGENIC_FREEZER
+            - NONE
+            - OTHER
+            - UNKNOWN
+          title: StorageEnum
+          type: string
+          $id: src/content_schemas/enums/StorageEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        type:
+          description: The type of a sample
+          enum:
+            - CF_DNA
+            - DEPLETED_RNA
+            - DS_DNA_CHIP
+            - FFPE_DNA
+            - FFPE_TOTAL_RNA
+            - GENOMIC_DNA
+            - PCR_PRODUCTS
+            - POLY_A_RNA
+            - SINGLE_CELL_DNA
+            - SINGLE_CELL_RNA
+            - SINGLE_CELL_NUCLEI
+            - SMALL_RNA
+            - TOTAL_RNA
+            - OTHER
+          title: SampleTypeEnum
+          type: string
+          $id: src/content_schemas/enums/SampleTypeEnum
+          $schema: https://json-schema.org/draft/2019-09/schema
+        xref:
+          description: One or more cross-references for this Sample (e.g., this
+            Sample may have an EBI BioSamples accession ID).
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      required:
+        - name
+        - description
+        - case_control_status
+        - biospecimen_age_at_sampling
+      title: Sample
+      type: object
+      $id: src/content_schemas/Sample
+      $schema: https://json-schema.org/draft/2019-09/schema
+    relations:
+      individual:
+        targetClass: Individual
+        mandatory:
+          origin: false
+          target: true
+        multiple:
+          origin: true
+          target: false

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/transformed.datapack.yaml
@@ -1,0 +1,75 @@
+datapack: 4.2.0
+resources:
+  DatasetStats:
+    GHGAD74245202504286:
+      content:
+        alias: DS_A
+        title: The complete-A dataset
+        description: An interesting dataset A of complete example set
+        types:
+          - A Type
+          - Another Type
+        dac_email: dac_institute_a@dac.dac
+        samples_summary:
+          count: 2
+          stats:
+            phenotypic_features:
+              Leukemia: 1
+            tissues:
+              blood: 1
+              subcutaneous adipose tissue: 1
+            sex:
+              MALE: 1
+        studies_summary:
+          count: 1
+          stats:
+            title: "The A Study"
+            accession: GHGAS90595893121388
+        experiments_summary:
+          count: 2
+          stats:
+            experiment_methods:
+              454_GS: 2
+        files_summary:
+          count: 7
+          stats:
+            formats:
+              FASTQ: 3
+              JSON: 1
+              TXT: 1
+              VCF: 2
+
+    GHGAD84882883098593:
+      content:
+        alias: DS_B
+        title: The complete-B dataset
+        description: An interesting dataset B of complete example set
+        types:
+          - And another Type
+        dac_email: dac_institute_a@dac.dac
+        samples_summary:
+          count: 2
+          stats:
+            phenotypic_features:
+              Leukemia: 1
+            tissues:
+              blood: 1
+              subcutaneous adipose tissue: 1
+            sex:
+              MALE: 1
+        studies_summary:
+          count: 1
+          stats:
+            title: "The A Study"
+            accession: GHGAS90595893121388
+        experiments_summary:
+          count: 2
+          stats:
+            experiment_methods:
+              454_GS: 2
+        files_summary:
+          count: 7
+          stats:
+            formats:
+              FASTQ: 6
+              TXT: 1

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/transformed.schemapack.yaml
@@ -1,0 +1,116 @@
+schemapack: 4.2.0
+globallyUniqueIds: true
+description: Metadata schema for the German Human Genome-Phenome Archive (GHGA)
+classes:
+  DatasetStats:
+    id:
+      propertyName: accession
+    content:
+      additionalProperties: false
+      description: A Dataset is a collection of Files that is prepared for
+        distribution and is tied to a Data Access Policy.
+      properties:
+        alias:
+          type: string
+        description:
+          type: string
+        title:
+          type: string
+        types:
+          items:
+            type: string
+          type: array
+        dac_email:
+          type: string
+        samples_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                tissues:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                sex:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+          required:
+            - count
+            - stats
+        studies_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                title:
+                  type: string
+                accession:
+                  type: string
+          required:
+            - count
+            - stats
+        experiments_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                experiment_methods:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+          required:
+            - count
+            - stats
+        files_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                format:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+          required:
+            - count
+            - stats
+      required:
+        - title
+        - alias
+        - description
+        - types
+        - dac_email
+        - samples_summary
+        - studies_summary
+        - experiments_summary
+        - files_summary
+      type: object
+      $schema: https://json-schema.org/draft/2019-09/schema

--- a/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/workflow.yaml
+++ b/tests/fixtures/example_workflows/ghga_aggregation_workflow_with_pam/workflow.yaml
@@ -1,0 +1,554 @@
+operations:
+- name: add_class
+  description: Add the Study class from the annotation
+  args:
+    class_name: Study
+    id_property_name: alias
+    content_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        types:
+          type: array
+          items:
+            type: string
+        ega_accession:
+          type: string
+        affiliations:
+          type: array
+          items:
+            type: string
+      required:
+      - title
+    relations: []
+- name: add_class
+  description: Add the DataAccessCommittee class from the annotation
+  args:
+    class_name: DataAccessCommittee
+    id_property_name: alias
+    content_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        institute:
+          type: string
+        ega_accession:
+          type: string
+      required:
+      - email
+    relations: []
+- name: add_class
+  description: Add the DataAccessPolicy class from the annotation
+  args:
+    class_name: DataAccessPolicy
+    id_property_name: alias
+    content_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        text:
+          type: string
+        url:
+          type: string
+        duo_permission_id:
+          type: string
+        duo_modifier_ids:
+          type: array
+          items:
+            type: string
+        ega_accession:
+          type: string
+      required: []
+    relations:
+    - relation_property_name: data_access_committee
+      targetClass: DataAccessCommittee
+      target_resources: dac_id
+      mandatory:
+        origin: false
+        target: true
+      multiple:
+        origin: true
+        target: false
+- name: add_class
+  description: Add the Dataset class, partitioning `files` across file classes
+  args:
+    class_name: Dataset
+    id_property_name: alias
+    content_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        types:
+          type: array
+          items:
+            type: string
+        ega_accession:
+          type: string
+      required:
+      - title
+      - description
+      - types
+    relations:
+    - relation_property_name: study
+      targetClass: Study
+      target_resources: study_id
+      mandatory:
+        origin: false
+        target: true
+      multiple:
+        origin: true
+        target: false
+    - relation_property_name: data_access_policy
+      targetClass: DataAccessPolicy
+      target_resources: dap_id
+      mandatory:
+        origin: false
+        target: true
+      multiple:
+        origin: true
+        target: false
+    - relation_property_name: research_data_files
+      targetClass: ResearchDataFile
+      target_resources: files
+      mandatory:
+        origin: false
+        target: false
+      multiple:
+        origin: false
+        target: true
+    - relation_property_name: process_data_files
+      targetClass: ProcessDataFile
+      target_resources: files
+      mandatory:
+        origin: false
+        target: false
+      multiple:
+        origin: false
+        target: true
+    - relation_property_name: individual_supporting_files
+      targetClass: IndividualSupportingFile
+      target_resources: files
+      mandatory:
+        origin: false
+        target: false
+      multiple:
+        origin: false
+        target: true
+    - relation_property_name: experiment_method_supporting_files
+      targetClass: ExperimentMethodSupportingFile
+      target_resources: files
+      mandatory:
+        origin: false
+        target: false
+      multiple:
+        origin: false
+        target: true
+    - relation_property_name: analysis_method_supporting_files
+      targetClass: AnalysisMethodSupportingFile
+      target_resources: files
+      mandatory:
+        origin: false
+        target: false
+      multiple:
+        origin: false
+        target: true
+- name: infer_relation
+  description: Infer relations for class Dataset
+  args:
+    class_name: Dataset
+    relation_name: '{{{ item.relation_name }}}'
+    relation_path: '{{{ item.relation_path }}}'
+  loop:
+  - relation_name: samples_from_individual_supporting_files
+    relation_path: Dataset(individual_supporting_files)>IndividualSupportingFile(individual)>Individual<(individual)Sample
+  - relation_name: samples_from_research_data_files
+    relation_path: Dataset(research_data_files)>ResearchDataFile(experiments)>Experiment(sample)>Sample
+  - relation_name: samples_from_experiment_supporting_files
+    relation_path: Dataset(experiment_method_supporting_files)>ExperimentMethodSupportingFile(experiment_method)>ExperimentMethod<(experiment_method)Experiment(sample)>Sample
+  - relation_name: samples_from_process_data_files
+    relation_path: Dataset(process_data_files)>ProcessDataFile(analysis)>Analysis(research_data_files)>ResearchDataFile(experiments)>Experiment(sample)>Sample
+  - relation_name: samples_from_analysis_method_supporting_files
+    relation_path: Dataset(analysis_method_supporting_files)>AnalysisMethodSupportingFile(analysis_method)>AnalysisMethod<(analysis_method)Analysis(research_data_files)>ResearchDataFile(experiments)>Experiment(sample)>Sample
+- name: merge_relations
+  description: Create {{{ item.target_relation }}} relation for each Dataset
+  args:
+    class_name: Dataset
+    source_relations:
+    - samples_from_individual_supporting_files
+    - samples_from_research_data_files
+    - samples_from_experiment_supporting_files
+    - samples_from_process_data_files
+    - samples_from_analysis_method_supporting_files
+    target_relation: samples
+    description: samples related to the dataset.
+    mandatory:
+      origin: false
+      target: false
+    multiple:
+      origin: true
+      target: true
+- name: infer_relation
+  description: Infer Individual relations for each Dataset
+  args:
+    class_name: Dataset
+    relation_name: individuals
+    relation_path: Dataset(samples)>Sample(individual)>Individual
+- name: infer_relation
+  description: Infer Experiment relations for class Dataset
+  args:
+    class_name: Dataset
+    relation_name: '{{{ item.relation_name }}}'
+    relation_path: '{{{ item.relation_path }}}'
+  loop:
+  - relation_name: experiments_from_research_data_files
+    relation_path: Dataset(research_data_files)>ResearchDataFile(experiments)>Experiment
+  - relation_name: experiments_from_individual_supporting_files
+    relation_path: Dataset(individual_supporting_files)>IndividualSupportingFile(individual)>Individual<(individual)Sample<(sample)Experiment
+  - relation_name: experiments_from_experiment_method_supporting_files
+    relation_path: Dataset(experiment_method_supporting_files)>ExperimentMethodSupportingFile(experiment_method)>ExperimentMethod<(experiment_method)Experiment
+  - relation_name: experiments_from_process_data_files
+    relation_path: Dataset(process_data_files)>ProcessDataFile(analysis)>Analysis(research_data_files)>ResearchDataFile(experiments)>Experiment
+  - relation_name: experiments_from_analysis_method_supporting_files
+    relation_path: Dataset(analysis_method_supporting_files)>AnalysisMethodSupportingFile(analysis_method)>AnalysisMethod<(analysis_method)Analysis(research_data_files)>ResearchDataFile(experiments)>Experiment
+- name: merge_relations
+  description: Create {{{ item.target_relation }}} relation for each Dataset
+  args:
+    class_name: Dataset
+    source_relations:
+    - experiments_from_research_data_files
+    - experiments_from_individual_supporting_files
+    - experiments_from_experiment_method_supporting_files
+    - experiments_from_process_data_files
+    - experiments_from_analysis_method_supporting_files
+    target_relation: experiments
+    description: experiments related to the dataset.
+    mandatory:
+      origin: false
+      target: false
+    multiple:
+      origin: true
+      target: true
+- name: transform_content
+  description: Add experiment_method.instrument_model field to the Experiment
+  args:
+    class_name: Experiment
+    content_schema:
+      additionalProperties: false
+      description: An Experiment is an investigation that consists of a coordinated set of actions and observations designed to generate data with the goal of verifying, falsifying, or establishing the validity of a hypothesis.
+      properties:
+        attributes:
+          description: Key/value pairs corresponding to an entity.
+          items:
+            $ref: src/content_schemas/Attribute
+          type:
+          - array
+          - 'null'
+        description:
+          description: A detailed description of this Experiment.
+          type:
+          - string
+          - 'null'
+        ega_accession:
+          description: The EGA accession of the 'Run' entity (EGAR).
+          type:
+          - string
+          - 'null'
+        title:
+          description: The title for this Experiment (e.g., GHGAE_PBMC_RNAseq).
+          type: string
+        type:
+          description: The type of this Experiment.
+          type:
+          - string
+          - 'null'
+        instrument_model:
+          description: Permitted values for the instrument model.
+          type: string
+      required:
+      - title
+      title: Experiment
+      type: object
+      $id: src/content_schemas/Experiment
+      $schema: https://json-schema.org/draft/2019-09/schema
+    embedding_profile:
+      sample: false
+    content_template_yaml: '{% for key in content_property_names %}
+
+      {% set value = original.get(key) %}
+
+      {% if value is not none %}
+
+      {{ key }}: {{ value | tojson }}
+
+      {% endif %}
+
+      {% endfor %}
+
+      instrument_model: {{ original.experiment_method["instrument_model"] }}
+
+      '
+- name: rename_id_property
+  description: Rename id property for each {{ class_name }}
+  args:
+    class_name: '{{{ item.class_name }}}'
+    id_property_name: '{{{ item.id_property_name }}}'
+  loop:
+  - class_name: Study
+    id_property_name: accession
+  - class_name: Dataset
+    id_property_name: accession
+- name: transform_content
+  description: Add alias to the content of Dataset
+  args:
+    class_name: Dataset
+    content_schema:
+      additionalProperties: false
+      description: A Dataset is a collection of Files that is prepared for distribution and is tied to a Data Access Policy.
+      properties:
+        description:
+          description: A description summarizing this Dataset.
+          type: string
+        ega_accession:
+          description: The EGA accession ID of an entity.
+          type:
+          - string
+          - 'null'
+        title:
+          description: A title for this Dataset.
+          type: string
+        types:
+          description: The type of this Dataset.
+          items:
+            type: string
+          type: array
+        alias:
+          type: string
+      required:
+      - title
+      - description
+      - types
+      - alias
+      title: Dataset
+      type: object
+      $id: src/content_schemas/Dataset
+      $schema: https://json-schema.org/draft/2019-09/schema
+    embedding_profile:
+      data_access_policy: false
+      study: false
+      samples:
+        individual: false
+      experiments:
+        sample: false
+        experiment_method: false
+      research_data_files:
+        dataset: false
+        experiments: false
+      process_data_files:
+        dataset: false
+        analysis: false
+      individual_supporting_files:
+        dataset: false
+        individual: false
+      experiment_method_supporting_files:
+        dataset: false
+        experiment_method: false
+      analysis_method_supporting_files:
+        dataset: false
+        analysis_method: false
+    content_template_yaml: '{% for key in content_property_names %}
+
+      {% set value = original.get(key) %}
+
+      {% if value is not none %}
+
+      {{ key }}: {{ value | tojson }}
+
+      {% endif %}
+
+      {% endfor %}
+
+      alias: {{ original[id_property_name] }}
+
+      '
+- name: replace_resource_ids
+  description: Replace resource ids of {{ class_name }}
+  args:
+    class_name: '{{{ item.class_name }}}'
+  loop:
+  - class_name: Study
+  - class_name: Dataset
+- name: duplicate_class
+  description: Create a duplicate of class Dataset named DatasetStats
+  args:
+    source_class_name: Dataset
+    target_class_name: DatasetStats
+- name: transform_content
+  description: Dataset stats
+  args:
+    class_name: DatasetStats
+    content_schema:
+      $schema: https://json-schema.org/draft/2019-09/schema
+      additionalProperties: false
+      description: A Dataset is a collection of Files that is prepared for distribution and is tied to a Data Access Policy.
+      properties:
+        alias:
+          type: string
+        description:
+          type: string
+        types:
+          type: array
+          items:
+            type: string
+        title:
+          type: string
+        dac_email:
+          type: string
+        samples_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                tissues:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                sex:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+          required:
+          - count
+          - stats
+        studies_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                title:
+                  type: string
+                accession:
+                  type: string
+          required:
+          - count
+          - stats
+        experiments_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                experiment_methods:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+          required:
+          - count
+          - stats
+        files_summary:
+          type: object
+          additionalProperties: true
+          properties:
+            count:
+              type: integer
+            stats:
+              type: object
+              additionalProperties: true
+              properties:
+                format:
+                  type: object
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: integer
+          required:
+          - count
+          - stats
+      required:
+      - title
+      - alias
+      - description
+      - types
+      - dac_email
+      - samples_summary
+      - studies_summary
+      - experiments_summary
+      - files_summary
+      type: object
+    embedding_profile:
+      samples:
+        individual: false
+      experiments:
+        sample: false
+        experiment_method: false
+      research_data_files:
+        dataset: false
+        experiments: false
+      process_data_files:
+        dataset: false
+        analysis: false
+      individual_supporting_files:
+        dataset: false
+        individual: false
+      experiment_method_supporting_files:
+        dataset: false
+        experiment_method: false
+      analysis_method_supporting_files:
+        dataset: false
+        analysis_method: false
+    content_template_yaml: "description: {{ original.description }}\nalias: {{ original.alias }}\ntypes: {{ original.types }}\ntitle: {{ original.title }}\ndac_email: {{ original.data_access_policy.data_access_committee.email }}\nsamples_summary:\n  count: {{ original.samples | length }}\n  stats:\n    phenotypic_features:\n      {% set term_counts = {} %}\n      {% for individual in original.individuals %}\n          {% for term in individual.phenotypic_features_terms %}\n              {% set _ = term_counts.update({term: term_counts.get(term, 0) + 1}) %}\n          {% endfor %}\n      {% endfor %}\n      {% for term, count in term_counts.items() %}\n      {{ term }} : {{ count }}\n      {% endfor %}\n    tissues:\n      {% for key, values in original.samples |  groupby(\"biospecimen_tissue_term\") %}\n        {{ key }}: {{ values | length }}\n      {% else %}\n        {}\n      {% endfor %}\n    sex:\n      {% for key, values in original.individuals |  groupby(\"sex\") %}\n        {{ key }}: {{ values | length }}\n      {% else %}\n        {}\n      {% endfor %}\nstudies_summary:\n  count: {{ [original.study.accession] | length }}\n  stats:\n    title: {{  original.study.title}}\n    accession: {{ original.study.accession }}\nexperiments_summary:\n  count: {{ original.experiments | length }}\n  stats:\n    experiment_methods:\n      {% for key, values in original.experiments |  groupby(\"instrument_model\") %}\n        {{ key }}: {{ values | length }}\n      {% else %}\n        {}\n      {% endfor %}\nfiles_summary:\n  {% set all_files = original.research_data_files + original.process_data_files + original.individual_supporting_files + original.experiment_method_supporting_files + original.analysis_method_supporting_files %}\n  count: {{ all_files | length }}\n  stats:\n    formats:\n      {% for key, values in all_files | groupby(\"format\") %}\n        {{ key }}: {{ values | length }}\n      {% else %}\n        {}\n      {% endfor %}\n"
+- name: delete_class
+  description: Delete class {{ item }}
+  args:
+    class_name: '{{{ item }}}'
+  loop:
+  - Analysis
+  - AnalysisMethod
+  - AnalysisMethodSupportingFile
+  - DataAccessCommittee
+  - DataAccessPolicy
+  - Dataset
+  - Experiment
+  - ExperimentMethod
+  - ExperimentMethodSupportingFile
+  - Individual
+  - IndividualSupportingFile
+  - ProcessDataFile
+  - ResearchDataFile
+  - Sample
+  - Study

--- a/tests/fixtures/example_workflows/infer_multiple/input.datapack.yaml
+++ b/tests/fixtures/example_workflows/infer_multiple/input.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/infer_multiple/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/infer_multiple/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   Dataset:
     dataset_1:

--- a/tests/fixtures/example_workflows/infer_multiple/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/infer_multiple/transformed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   Dataset:
     id:

--- a/tests/fixtures/example_workflows/rename_id_property_set_global_id_uniqueness/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_set_global_id_uniqueness/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     file_a:

--- a/tests/fixtures/example_workflows/rename_id_property_set_global_id_uniqueness/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_set_global_id_uniqueness/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/example_workflows/rename_id_property_transform_content_update_resource_ids/transformed.datapack.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_transform_content_update_resource_ids/transformed.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 4.0.0
+datapack: 4.2.0
 resources:
   File:
     TESTS0000000001:

--- a/tests/fixtures/example_workflows/rename_id_property_transform_content_update_resource_ids/transformed.schemapack.yaml
+++ b/tests/fixtures/example_workflows/rename_id_property_transform_content_update_resource_ids/transformed.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/fixtures/transformations.py
+++ b/tests/fixtures/transformations.py
@@ -25,7 +25,7 @@ from schemapack.spec.schemapack import SchemaPack
 
 from metldata.builtin_transformations.registry import TRANSFORMATION_REGISTRY
 from metldata.transform.base import TransformationDefinition
-from tests.fixtures.annotation import AccessionAnnotation, EmptySubmissionAnnotation
+from tests.fixtures.annotation import Annotation
 from tests.fixtures.data import ADVANCED_DATA
 from tests.fixtures.models import ADVANCED_MODEL
 from tests.fixtures.utils import BASE_DIR, read_yaml
@@ -76,9 +76,9 @@ def _read_test_case(
     transformed_data = load_datapack(transformed_data_path)
     config = transformation_definition.config_cls(**read_yaml(config_path))
     annotation = (
-        AccessionAnnotation(**read_yaml(annotation_path))
+        Annotation(**read_yaml(annotation_path))
         if annotation_path.exists()
-        else EmptySubmissionAnnotation()
+        else Annotation()
     )
 
     return TransformationTestCase(

--- a/tests/fixtures/workflow.py
+++ b/tests/fixtures/workflow.py
@@ -29,7 +29,7 @@ from schemapack.spec.schemapack import SchemaPack
 from metldata.builtin_transformations.registry import TRANSFORMATION_REGISTRY
 from metldata.workflow.base import Workflow, WorkflowTemplate
 from metldata.workflow.builder import WorkflowBuilder
-from tests.fixtures.annotation import AccessionAnnotation, EmptySubmissionAnnotation
+from tests.fixtures.annotation import Annotation
 from tests.fixtures.data import ADVANCED_DATA
 from tests.fixtures.models import ADVANCED_MODEL
 from tests.fixtures.utils import BASE_DIR, read_yaml
@@ -48,6 +48,7 @@ WORKFLOW_BY_NAME = [
     "rename_id_property_set_global_id_uniqueness",
     "rename_id_property_transform_content_update_resource_ids",
     "ghga_aggregation_workflow",
+    "ghga_aggregation_workflow_with_pam",
 ]
 VALIDATION_WORKFLOWS = [
     "pre_transform_validation_failure",
@@ -111,9 +112,9 @@ def _read_test_case(
     )
     workflow = _get_workflow(workflow_path)
     annotation = (
-        AccessionAnnotation(**read_yaml(annotation_path))
+        Annotation(**read_yaml(annotation_path))
         if annotation_path.exists()
-        else EmptySubmissionAnnotation()
+        else Annotation()
     )
 
     return WorkflowTestCase(

--- a/tests/fixtures/workflow_validation/pre_transform_validation_failure/input.schemapack.yaml
+++ b/tests/fixtures/workflow_validation/pre_transform_validation_failure/input.schemapack.yaml
@@ -1,5 +1,5 @@
 # a more advanced schemapack:
-schemapack: 4.0.0
+schemapack: 4.2.0
 classes:
   File:
     id:

--- a/tests/transform/test_handling.py
+++ b/tests/transform/test_handling.py
@@ -37,11 +37,13 @@ from metldata.transform.handling import (
     PreTransformValidationError,
     TransformationHandler,
 )
-from tests.fixtures.annotation import EMPTY_SUBMISSION_ANNOTATION
+from tests.fixtures.annotation import Annotation
 from tests.fixtures.data import INVALID_MINIMAL_DATA, MINIMAL_DATA
 from tests.fixtures.models import MINIMAL_MODEL
 
 pytestmark = pytest.mark.parametrize("validate", [True, False])
+
+EMPTY_SUBMISSION_ANNOTATION = Annotation()
 
 
 def test_transformation_handler_happy(validate: bool):


### PR DESCRIPTION
Introduces a new builtin transformation, `add_class`, that adds a brand-new class (its schema definition + resources) to a schemapack model and datapack from an external annotation. This enables building a class whose resources and relations are supplied rather than inferred from existing data.

A key capability: a single annotation field can hold foreign-key IDs that span multiple target classes. By configuring one relation spec per `targetClass`, the transformation partitions those IDs across classes — keeping, per relation, only the IDs that actually exist in that class.